### PR TITLE
observability: log-based backup-failure alerts (Loki ruler → Telegram)

### DIFF
--- a/apps/observability/loki-values.yaml
+++ b/apps/observability/loki-values.yaml
@@ -32,6 +32,24 @@ loki:
   # Disable the experimental pattern ingester — not needed, extra moving part.
   pattern_ingester:
     enabled: false
+  # Ruler: evaluate LogQL alerting rules and push to the Prometheus Alertmanager
+  # (so log-based alerts share the same Telegram pipeline as the metric alerts).
+  # Rules are read from a local dir; single-tenant Loki (auth_enabled:false) uses
+  # the tenant id `fake`, so rule files live under <directory>/fake/ — mounted
+  # from the `loki-alerting-rules` ConfigMap via singleBinary.extraVolume* below.
+  rulerConfig:
+    wal:
+      dir: /var/loki/ruler-wal
+    storage:
+      type: local
+      local:
+        directory: /rules
+    rule_path: /var/loki/ruler-temp
+    alertmanager_url: http://prometheus-alertmanager.observability.svc.cluster.local:9093
+    enable_alertmanager_v2: true
+    enable_api: true
+    evaluation_interval: 1m
+    poll_interval: 1m
 
 # The single Loki process. Service `loki` :3100 is the read/write entrypoint
 # (gateway disabled below). Push URL used by Alloy + Grafana datasource:
@@ -47,6 +65,16 @@ singleBinary:
       memory: 256Mi
     limits:
       memory: 1Gi
+  # Mount the ruler rule files (tenant `fake`) from the ConfigMap. Matches
+  # rulerConfig.storage.local.directory=/rules above.
+  extraVolumes:
+    - name: loki-alerting-rules
+      configMap:
+        name: loki-alerting-rules
+  extraVolumeMounts:
+    - name: loki-alerting-rules
+      mountPath: /rules/fake
+      readOnly: true
 
 # Force every scalable/microservices component off — Monolithic only.
 read:

--- a/apps/operators/cnpg/cloudnativepg-operator.yaml
+++ b/apps/operators/cnpg/cloudnativepg-operator.yaml
@@ -9,6 +9,13 @@ spec:
     repoURL: https://cloudnative-pg.github.io/charts
     chart: cloudnative-pg
     targetRevision: "0.26.1" # Use a specific chart version
+    helm:
+      valuesObject:
+        # Ship the operator's logs to Loki so the CNPGBaseBackupFailed log alert
+        # can see base/scheduled backup failures (which the barman plugin does not
+        # expose as metrics). Alloy collects pods carrying this label.
+        podLabels:
+          logs.cjbarroso.com/collect: "true"
   destination:
     server: https://kubernetes.default.svc
     namespace: cnpg-system

--- a/src/observability/loki-alerting-rules-configmap.yaml
+++ b/src/observability/loki-alerting-rules-configmap.yaml
@@ -1,0 +1,38 @@
+# Loki ruler alerting rules — log-based backup-failure alerts for CNPG.
+# Mounted into the Loki pod at /rules/fake (tenant `fake`, single-tenant Loki)
+# via singleBinary.extraVolume* in apps/observability/loki-values.yaml; the ruler
+# evaluates them and pushes to the Prometheus Alertmanager, which routes
+# severity=~"warning|critical" to Telegram.
+#
+# These COMPLEMENT the metric alert CNPGWALArchivingFailing (prometheus-values):
+#   - CNPGBaseBackupFailed: catches a failed base/scheduled backup — the gap the
+#     metric can't see, since the barman *plugin* doesn't populate backup-status
+#     metrics. Sourced from the operator log (needs the cnpg operator pod labelled
+#     logs.cjbarroso.com/collect:"true").
+#   - CNPGWalArchiveErrorsLog: fast, log-based early warning on WAL-archive errors
+#     (fires on the first "archive command failed" line; the metric alert escalates
+#     to critical only after 15m sustained).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-alerting-rules
+  namespace: observability
+data:
+  cnpg-backup.yaml: |
+    groups:
+      - name: cnpg-backup
+        rules:
+          - alert: CNPGBaseBackupFailed
+            expr: sum(count_over_time({namespace="cnpg-system"} |= `"controllerKind":"Backup"` |= `"level":"error"` [10m])) > 0
+            labels:
+              severity: critical
+            annotations:
+              summary: "CNPG base backup failed (operator log)"
+              description: "The CloudNativePG operator logged an error for a Backup resource in the last 10m — a scheduled/base backup failed. Check: kubectl -n hhccia-v2 get backups.postgresql.cnpg.io, and the operator logs in cnpg-system."
+          - alert: CNPGWalArchiveErrorsLog
+            expr: sum(count_over_time({namespace="hhccia-v2", container="postgres"} |= `archive command failed` [10m])) > 0
+            labels:
+              severity: warning
+            annotations:
+              summary: "Postgres WAL archiving errors (hhccia-core-db)"
+              description: "Postgres logged 'archive command failed' in hhccia-v2 in the last 10m — WAL archiving to R2 is failing. If sustained it breaks PITR/backups (the CNPGWALArchivingFailing metric alert escalates to critical after 15m)."


### PR DESCRIPTION
Complements the metric alert `CNPGWALArchivingFailing` with **log-based** backup-failure detection, including the gap the metric can't cover — **failed base/scheduled backups** (the barman plugin doesn't expose backup-status metrics).

- **Loki ruler** enabled (local rule store, push to the Prometheus Alertmanager v2); rules mounted from a ConfigMap.
- **CNPGBaseBackupFailed** (critical): the operator logs an error on a `Backup` resource.
- **CNPGWalArchiveErrorsLog** (warning): postgres logs `archive command failed` — fast early warning before the 15m metric critical.
- **cnpg-operator** pod labelled `logs.cjbarroso.com/collect:"true"` so its logs reach Loki (required for the base-backup alert).

Both LogQL expressions validated against live Loki (parse; empty/healthy now). Routes to Telegram via the existing `severity=~"warning|critical"` route.