### PR TITLE
observability: Grafana logs deep-link in the backup alerts

### DIFF
--- a/apps/observability/grafana-values.yaml
+++ b/apps/observability/grafana-values.yaml
@@ -182,6 +182,68 @@ dashboards:
             }
           ]
         }
+    # Curated log view for the CNPG backup alerts. Stable uid `cnpg-backup-logs`
+    # so the Alertmanager Telegram messages deep-link to it via the alerts'
+    # `logs` annotation (https://logs.cjbarroso.com/d/cnpg-backup-logs). Panels
+    # reference the Loki datasource by name (resolved by Grafana at load).
+    cnpg-backup-logs:
+      json: |
+        {
+          "uid": "cnpg-backup-logs",
+          "title": "CNPG Backups — hhccia-core-db logs",
+          "tags": ["cnpg", "backup", "logs"],
+          "schemaVersion": 39,
+          "refresh": "1m",
+          "time": { "from": "now-6h", "to": "now" },
+          "templating": { "list": [] },
+          "panels": [
+            {
+              "id": 1,
+              "type": "logs",
+              "title": "Barman plugin errors — backup / WAL / retention (alert: CNPGBackupFailed)",
+              "datasource": "Loki",
+              "gridPos": { "h": 11, "w": 24, "x": 0, "y": 0 },
+              "options": { "showTime": true, "wrapLogMessage": true, "enableLogDetails": true, "dedupStrategy": "none", "sortOrder": "Descending" },
+              "targets": [
+                {
+                  "refId": "A",
+                  "datasource": "Loki",
+                  "expr": "{namespace=\"hhccia-v2\", container=\"plugin-barman-cloud\"} | json | level=\"error\""
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "type": "logs",
+              "title": "Postgres WAL archiver failures (alert: CNPGWalArchiveErrorsLog)",
+              "datasource": "Loki",
+              "gridPos": { "h": 8, "w": 24, "x": 0, "y": 11 },
+              "options": { "showTime": true, "wrapLogMessage": true, "dedupStrategy": "none", "sortOrder": "Descending" },
+              "targets": [
+                {
+                  "refId": "A",
+                  "datasource": "Loki",
+                  "expr": "{namespace=\"hhccia-v2\", container=\"postgres\"} |= \"archive command failed\""
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "type": "logs",
+              "title": "All hhccia-core-db logs (context)",
+              "datasource": "Loki",
+              "gridPos": { "h": 10, "w": 24, "x": 0, "y": 19 },
+              "options": { "showTime": true, "wrapLogMessage": true, "dedupStrategy": "none", "sortOrder": "Descending" },
+              "targets": [
+                {
+                  "refId": "A",
+                  "datasource": "Loki",
+                  "expr": "{namespace=\"hhccia-v2\", pod=~\"hhccia-core-db-.*\"}"
+                }
+              ]
+            }
+          ]
+        }
 
 ingress:
   enabled: true

--- a/apps/observability/prometheus-values.yaml
+++ b/apps/observability/prometheus-values.yaml
@@ -123,6 +123,7 @@ serverFiles:
             annotations:
               summary: "Postgres WAL archiving / backups failing ({{ $labels.cnpg_io_cluster }})"
               description: "CNPG cluster {{ $labels.cnpg_io_cluster }} (ns {{ $labels.namespace }}): the primary's latest WAL-archive attempt to R2 failed and has not succeeded for >15m — backups & point-in-time recovery are at risk. Check the R2 credentials (sealed secret hhccia-core-db-backup-creds) and the barman ObjectStore."
+              logs: "https://logs.cjbarroso.com/d/cnpg-backup-logs?from=now-3h&to=now"
 
 # --- Alertmanager: minimal, exists only to drive the healthchecks.io heartbeat ---
 # Stateless (no PVC), tiny. The server auto-discovers it via kubernetes_sd.
@@ -193,4 +194,5 @@ alertmanager:
               {{ range .Alerts }}<b>{{ .Labels.alertname }}</b> — {{ .Status | toUpper }}
               {{ .Annotations.description }}
               {{ with .Annotations.dashboard }}📊 <a href="{{ . }}">Open dashboard</a>
+              {{ end }}{{ with .Annotations.logs }}📋 <a href="{{ . }}">View logs</a>
               {{ end }}{{ end }}

--- a/src/observability/loki-alerting-rules-configmap.yaml
+++ b/src/observability/loki-alerting-rules-configmap.yaml
@@ -30,6 +30,7 @@ data:
             annotations:
               summary: "CNPG backup failing (hhccia-core-db)"
               description: "The barman-cloud plugin logged errors for hhccia-core-db in the last 10m — a base backup, WAL archive, or retention operation to R2 is failing (e.g. bad/expired R2 credentials or unreachable bucket). Check: kubectl -n hhccia-v2 get backups.postgresql.cnpg.io and the plugin-barman-cloud container logs."
+              logs: "https://logs.cjbarroso.com/d/cnpg-backup-logs?from=now-6h&to=now"
           - alert: CNPGWalArchiveErrorsLog
             expr: sum(count_over_time({namespace="hhccia-v2", container="postgres"} |= `archive command failed` [10m])) > 0
             labels:
@@ -37,3 +38,4 @@ data:
             annotations:
               summary: "Postgres WAL archiving errors (hhccia-core-db)"
               description: "Postgres logged 'archive command failed' in hhccia-v2 in the last 10m — WAL archiving to R2 is failing. If sustained it breaks PITR/backups (the CNPGWALArchivingFailing metric alert escalates to critical after 15m)."
+              logs: "https://logs.cjbarroso.com/d/cnpg-backup-logs?from=now-6h&to=now"


### PR DESCRIPTION
Adds a one-click **View logs** link to the backup-failure alerts (Telegram), opening a curated Grafana dashboard `cnpg-backup-logs` (barman-plugin errors + postgres WAL-archive failures + full hhccia-core-db logs). Same pattern as the existing `node-alerts` deep-link. Applies to CNPGBackupFailed, CNPGWalArchiveErrorsLog (Loki) and CNPGWALArchivingFailing (metric).