### PR TITLE
dr: Velero stateful-namespace schedule + Authentik OIDC config export

### DIFF
--- a/apps/authentik/authentik.yaml
+++ b/apps/authentik/authentik.yaml
@@ -9,6 +9,10 @@ spec:
     repoURL: 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
     path: src/authentik
     targetRevision: master
+    directory:
+      # The OIDC config export is documentation/backup, not a deployable manifest —
+      # keep Argo from trying to apply it.
+      exclude: 'authentik-oidc-export.*'
   destination:
     server: https://kubernetes.default.svc
     namespace: authentik

--- a/apps/velero/values-production.yaml
+++ b/apps/velero/values-production.yaml
@@ -24,8 +24,27 @@ credentials:
   useSecret: true
   existingSecret: cloud-credentials
 
-# nexoflow-daily schedule removed 2026-05-30: n8n/nexoflow stack decommissioned.
-schedules: {}
+# Daily file-system backup of the cluster's stateful namespaces → R2 (bucket
+# `velero-backups`), 30-day retention. Covers the irreproducible state that is
+# NOT in Git: Authentik Postgres (SSO/OIDC config), Vaultwarden (password vault),
+# and the `default` namespace (Gitea repos + DB). Everything else is redeployable
+# from Git, so it's intentionally out of scope (see
+# `Reference/Disaster Preparedness - full backup coverage plan.md`).
+#
+# NOTE: these are CRASH-CONSISTENT file-system backups of live volumes (Postgres
+# replays WAL on restart; fine for the accepted 1–2 day RTO). Hardening follow-up:
+# add pre-backup hooks (pg_dump / `sqlite3 .backup` for Vaultwarden) for logically
+# clean dumps.
+schedules:
+  stateful-daily:
+    schedule: "0 2 * * *"          # 02:00 daily
+    template:
+      includedNamespaces:
+        - authentik
+        - vaultwarden
+        - default
+      defaultVolumesToFsBackup: true
+      ttl: 720h                     # 30 days
 
 upgradeCRDs: false # Do not upgrade CRDs. Fixes installation issues.
 kubectl:

--- a/src/authentik/authentik-oidc-export.README.md
+++ b/src/authentik/authentik-oidc-export.README.md
@@ -1,0 +1,45 @@
+# Authentik OIDC config export (`authentik-oidc-export.json`)
+
+A **sanitized, point-in-time export** of Authentik's OIDC **providers** and
+**applications** — the SSO config that is otherwise only in the Authentik
+Postgres DB and is configured **by hand** (the in-repo `blueprints.yaml` is not
+applied; see the `project_authentik_config_manual` note). This file makes that
+config **documented and reproducible**, so it isn't a single copy in the DB.
+
+## What's captured
+- **Providers** (`authentik_providers_oauth2.oauth2provider`): `client_id`,
+  `client_type`, **`_redirect_uris`** (the critical bit), token validities,
+  `sub_mode`, `signing_key` (a UUID reference, not key material), etc.
+- **Applications** (`authentik_core.application`): name, slug, launch URL.
+
+Current contents (2026-05-30): provider `hhccia-front` (public/PKCE — front v2,
+redirect URIs for `hhccia-v2.cjbarroso.com`, `medaudit.irupeconsultores.com`,
+`localhost:4200`) and the Grafana provider (confidential, redirect
+`logs.cjbarroso.com/login/generic_oauth`); apps `HHCCIA` and `Grafana`.
+
+## Secrets
+`client_secret` is **REDACTED** — it is not stored in Git. The real values live in:
+- the **Velero backup of the Authentik DB** (ns `authentik`, daily `stateful-daily` schedule), and
+- for Grafana, the sealed secret `grafana-secrets` (`oidc-client-secret`).
+`hhccia-front` is a **public** client (PKCE) — it has no usable client secret.
+
+## How to regenerate this export
+`ak export_blueprint` is currently broken in this Authentik version
+(`KeyError: 'serializer'`), so use Django `dumpdata`:
+```powershell
+$env:KUBECONFIG = "C:\Users\Usuario\.kube\nexoflow.config"
+kubectl -n authentik exec deploy/authentik-server -- `
+  ak dumpdata authentik_providers_oauth2.OAuth2Provider authentik_core.Application --indent 2 > export.json
+# then redact `client_secret` before committing
+```
+
+## Using it in disaster recovery
+Preferred path: restore the Authentik DB from the Velero backup (config + secrets
+come back intact). If instead Authentik is rebuilt fresh, recreate these
+providers/apps (by hand from this file, or `ak loaddata` then fix secrets):
+set the **redirect URIs exactly as listed**, regenerate `client_secret`, and
+update the consumer — Grafana → reseal `grafana-secrets`; `hhccia-front` needs
+none (public/PKCE). See `Reference/Disaster Preparedness - full backup coverage plan.md`
+in the HHCCIA hub.
+
+> This is a **point-in-time snapshot** — re-run the export after changing OIDC config.

--- a/src/authentik/authentik-oidc-export.json
+++ b/src/authentik/authentik-oidc-export.json
@@ -1,0 +1,88 @@
+[
+  {
+    "model": "authentik_providers_oauth2.oauth2provider",
+    "pk": 1,
+    "fields": {
+      "client_type": "public",
+      "client_id": "hhccia-front",
+      "client_secret": "REDACTED - in the Velero Authentik-DB backup; regenerate if recreating",
+      "_redirect_uris": [
+        {
+          "url": "https://hhccia-v2.cjbarroso.com/callback",
+          "matching_mode": "strict"
+        },
+        {
+          "url": "http://localhost:4200/callback",
+          "matching_mode": "strict"
+        },
+        {
+          "url": "https://medaudit.irupeconsultores.com/callback",
+          "matching_mode": "strict"
+        }
+      ],
+      "include_claims_in_id_token": true,
+      "access_code_validity": "minutes=1",
+      "access_token_validity": "hours=1",
+      "refresh_token_validity": "days=30",
+      "sub_mode": "hashed_user_id",
+      "issuer_mode": "per_provider",
+      "signing_key": "36e5dc64-f4d4-4c97-a6fe-f88874713f0b",
+      "encryption_key": null,
+      "jwks_sources": []
+    }
+  },
+  {
+    "model": "authentik_providers_oauth2.oauth2provider",
+    "pk": 3,
+    "fields": {
+      "client_type": "confidential",
+      "client_id": "rQFaae3ZNFijg7YwpNP41fKG7jhT0bHESuDpyp5T",
+      "client_secret": "REDACTED - in the Velero Authentik-DB backup; regenerate if recreating",
+      "_redirect_uris": [
+        {
+          "url": "https://logs.cjbarroso.com/login/generic_oauth",
+          "matching_mode": "strict"
+        }
+      ],
+      "include_claims_in_id_token": true,
+      "access_code_validity": "minutes=1",
+      "access_token_validity": "minutes=5",
+      "refresh_token_validity": "days=30",
+      "sub_mode": "hashed_user_id",
+      "issuer_mode": "per_provider",
+      "signing_key": "36e5dc64-f4d4-4c97-a6fe-f88874713f0b",
+      "encryption_key": null,
+      "jwks_sources": []
+    }
+  },
+  {
+    "model": "authentik_core.application",
+    "pk": "35ceefeb-9a9f-40d7-b5bc-9871ff6f75ba",
+    "fields": {
+      "name": "HHCCIA",
+      "slug": "hhccia",
+      "group": "",
+      "provider": 1,
+      "meta_launch_url": "https://hhccia-v2.cjbarroso.com/",
+      "open_in_new_tab": false,
+      "meta_icon": "",
+      "meta_description": "",
+      "meta_publisher": ""
+    }
+  },
+  {
+    "model": "authentik_core.application",
+    "pk": "dd50723c-a5c7-47c3-854d-89a8012be1f3",
+    "fields": {
+      "name": "Grafana",
+      "slug": "grafana",
+      "group": "",
+      "provider": 3,
+      "meta_launch_url": "",
+      "open_in_new_tab": false,
+      "meta_icon": "",
+      "meta_description": "",
+      "meta_publisher": ""
+    }
+  }
+]


### PR DESCRIPTION
Implements the top backup-coverage gaps from the disaster-preparedness plan: a daily Velero FS backup of authentik/vaultwarden/default → R2 (30d), and a sanitized Authentik OIDC config export committed to Git (redirect URIs + provider/app config; secrets redacted).