### PR TITLE
dr: logical backup hooks (Authentik pg_dumpall + Vaultwarden sqlite .backup)

### DIFF
--- a/apps/vaultwarden-backup.yaml
+++ b/apps/vaultwarden-backup.yaml
@@ -1,0 +1,22 @@
+# Deploys the Vaultwarden SQLite backup CronJob (src/vaultwarden/). Separate from
+# the vaultwarden Helm app because the gabe565 chart can't host the extra workload.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vaultwarden-backup
+  namespace: argocd
+spec:
+  project: personales
+  source:
+    repoURL: https://github.com/cjbarroso/nexoflow-k8s-apps.git
+    path: src/vaultwarden
+    targetRevision: master
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vaultwarden
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/velero/values-production.yaml
+++ b/apps/velero/values-production.yaml
@@ -45,6 +45,25 @@ schedules:
         - default
       defaultVolumesToFsBackup: true
       ttl: 720h                     # 30 days
+      hooks:
+        resources:
+          # Logically-clean dump of the Authentik DB (SSO/OIDC config) just before
+          # the file-system backup, written onto the backed-up data PVC. Gives a
+          # restorable `pg_dumpall` alongside the crash-consistent data dir.
+          - name: authentik-pg-dump
+            includedNamespaces: [authentik]
+            labelSelector:
+              matchLabels:
+                app: authentik-pg
+            pre:
+              - exec:
+                  container: postgres
+                  command:
+                    - /bin/sh
+                    - -c
+                    - 'pg_dumpall -U "$POSTGRES_USER" -f /var/lib/postgresql/data/velero-dump.sql'
+                  onError: Continue   # never let a hook failure abort the FS backup
+                  timeout: 10m
 
 upgradeCRDs: false # Do not upgrade CRDs. Fixes installation issues.
 kubectl:

--- a/src/vaultwarden/vaultwarden-sqlite-backup-cronjob.yaml
+++ b/src/vaultwarden/vaultwarden-sqlite-backup-cronjob.yaml
@@ -1,0 +1,55 @@
+# Consistent SQLite backup of the Vaultwarden vault, for Velero to capture.
+#
+# Why: the Vaultwarden image has no `sqlite3`, runs non-root, and the gabe565
+# chart can't host a sidecar — so a Velero pre-hook can't dump the DB. This
+# CronJob mounts the same `vaultwarden-data` PVC (RWO, same single node) and uses
+# SQLite's online backup API to write a guaranteed-consistent `db.backup.sqlite3`
+# onto the volume. The Velero `stateful-daily` schedule (02:00) then backs it up;
+# this runs at 01:30 so the consistent copy is fresh in each Velero backup.
+#
+# Online `.backup` is safe against the live Vaultwarden process (it's the SQLite
+# backup API, designed for concurrent access) and only READS the live DB.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vaultwarden-sqlite-backup
+  namespace: vaultwarden
+spec:
+  schedule: "30 1 * * *"          # 01:30, before the 02:00 Velero backup
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app: vaultwarden-sqlite-backup
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsUser: 0            # root: install sqlite + read the nobody-owned DB
+          containers:
+            - name: sqlite-backup
+              image: alpine:3.20
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  apk add --no-cache sqlite >/dev/null
+                  if [ ! -f /data/db.sqlite3 ]; then echo "no db.sqlite3 — nothing to back up"; exit 0; fi
+                  # Consistent online backup → single self-contained file (no -wal).
+                  sqlite3 /data/db.sqlite3 ".backup '/data/db.backup.sqlite3'"
+                  # Fail loudly if the backup is corrupt.
+                  sqlite3 /data/db.backup.sqlite3 'PRAGMA integrity_check;'
+                  echo "vaultwarden sqlite backup OK ($(date -u +%FT%TZ)) size=$(wc -c </data/db.backup.sqlite3)"
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: vaultwarden-data


### PR DESCRIPTION
Hardens the stateful backups: Velero pre-hook does pg_dumpall on the Authentik DB; a daily CronJob does a consistent SQLite online .backup of the Vaultwarden vault (the image has no sqlite3 and the chart can't host a sidecar, so it's a standalone CronJob + small Argo app). Both land on their PVCs for the 02:00 Velero backup to capture.