### PR TITLE
feat(hhccia-v2): VOICE_EDIT_MODEL for core voice editor

### DIFF
--- a/src/hhccia-v2/hhccia-core.yaml
+++ b/src/hhccia-v2/hhccia-core.yaml
@@ -38,6 +38,10 @@ spec:
               value: "gemini"          # real Gemini; requires GEMINI_API_KEY in hhccia-core-secrets
             - name: GEMINI_MODEL
               value: "gemini-3.5-flash"
+            # Small/fast model for the /text-edit voice editor (reuses GEMINI_API_KEY).
+            # Bump to a 3.x flash-lite if/when preferred; this GA id is known-good.
+            - name: VOICE_EDIT_MODEL
+              value: "gemini-2.5-flash-lite"
             - name: DATABASE_URL
               valueFrom: { secretKeyRef: { name: hhccia-core-secrets, key: DATABASE_URL } }
             - name: GEMINI_API_KEY


### PR DESCRIPTION
Pins `VOICE_EDIT_MODEL=gemini-2.5-flash-lite` on the hhccia-core deployment for the new `/text-edit` voice editor. Reuses the existing `GEMINI_API_KEY` from `hhccia-core-secrets`, so no secret change is needed -- additive env var only.

Pairs with hhccia-core / hhccia-front `feat/voice-text-edit`.

Generated with [Claude Code](https://claude.com/claude-code)