### PR TITLE
chore(hhccia-v2): VOICE_EDIT_MODEL=gemini-flash-lite-latest

### DIFF
--- a/src/hhccia-v2/hhccia-core.yaml
+++ b/src/hhccia-v2/hhccia-core.yaml
@@ -39,9 +39,9 @@ spec:
             - name: GEMINI_MODEL
               value: "gemini-3.5-flash"
             # Small/fast model for the /text-edit voice editor (reuses GEMINI_API_KEY).
-            # Bump to a 3.x flash-lite if/when preferred; this GA id is known-good.
+            # Rolling alias: always the latest flash-lite without a manual bump.
             - name: VOICE_EDIT_MODEL
-              value: "gemini-2.5-flash-lite"
+              value: "gemini-flash-lite-latest"
             - name: DATABASE_URL
               valueFrom: { secretKeyRef: { name: hhccia-core-secrets, key: DATABASE_URL } }
             - name: GEMINI_API_KEY


### PR DESCRIPTION
Sets `VOICE_EDIT_MODEL=gemini-flash-lite-latest` on the hhccia-core deployment (rolling alias; reuses the existing `GEMINI_API_KEY`). This is the production-effective value for the `/text-edit` voice editor. Pairs with the hhccia-core code change.

Generated with [Claude Code](https://claude.com/claude-code)