### PR TITLE
chore(hhccia-v2): enable automated sync (prune + selfHeal)

### DIFF
--- a/apps/hhccia-v2/hhccia-v2.yaml
+++ b/apps/hhccia-v2/hhccia-v2.yaml
@@ -17,6 +17,13 @@ spec:
     server: https://kubernetes.default.svc
     namespace: hhccia-v2
   syncPolicy:
-    # Manual sync on purpose while v2 is in testing — flip to automated later.
+    # v2 is the only live stack now — automated like every other app in this repo.
+    # selfHeal reverts manual drift; prune removes resources dropped from Git.
+    # Note: deployments pin :latest, so Argo won't auto-deploy new images (the
+    # manifest digest is unchanged) — a code rollout still needs a
+    # `kubectl -n hhccia-v2 rollout restart`.
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
Enables `automated` sync (`prune: true`, `selfHeal: true`) on the hhccia-v2 Application, bringing it in line with every other app in the repo. It was the lone manual-sync exception, kept manual while v2 was in testing; v2 is now the only live stack.

Removes the manual `argocd app sync` step for manifest changes. Note: deployments pin `:latest`, so Argo still won't auto-deploy new images (the manifest digest is unchanged) -- a code rollout still needs `kubectl -n hhccia-v2 rollout restart`.

The root app-of-apps (auto-synced) will apply this to the live Application within a few minutes.

Generated with [Claude Code](https://claude.com/claude-code)
