### PR TITLE
feat(observability): alert + dashboard for Gemini API access health

### DIFF
--- a/apps/observability/grafana-values.yaml
+++ b/apps/observability/grafana-values.yaml
@@ -462,6 +462,71 @@ dashboards:
             }
           ]
         }
+    # Gemini API ACCESS health (availability, not cost) — log-derived from the
+    # hhccia-core Gemini HTTP results in Loki. Companion to the Loki alerts
+    # GeminiAccessErrors (warning) + GeminiRecordsDeadLettered (critical); their
+    # Telegram messages deep-link here via the `dashboard` annotation. Stable uid
+    # `gemini-health`. Panels reference the Loki datasource by name. Error series
+    # match the Gemini host + a 4xx/5xx status; success = "200 OK".
+    gemini-health:
+      json: |
+        {
+          "uid": "gemini-health",
+          "title": "Gemini — Salud de acceso (errores / éxitos / dead-letter)",
+          "tags": ["gemini", "hhccia", "logs", "alerts"],
+          "schemaVersion": 39,
+          "refresh": "1m",
+          "time": { "from": "now-6h", "to": "now" },
+          "templating": { "list": [] },
+          "panels": [
+            {
+              "id": 1, "type": "stat", "title": "Errores Gemini 4xx/5xx (15m) — alerta: GeminiAccessErrors", "datasource": "Loki",
+              "gridPos": { "h": 4, "w": 8, "x": 0, "y": 0 },
+              "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } }, "overrides": [] },
+              "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
+              "targets": [ { "refId": "A", "datasource": "Loki", "queryType": "instant", "expr": "sum(count_over_time({namespace=\"hhccia-v2\", container=\"hhccia-core\"} |= \"generativelanguage.googleapis.com\" |~ \"HTTP/1.1 [45]\" [15m]))" } ]
+            },
+            {
+              "id": 2, "type": "stat", "title": "Registros a dead-letter (1h) — alerta: GeminiRecordsDeadLettered", "datasource": "Loki",
+              "gridPos": { "h": 4, "w": 8, "x": 8, "y": 0 },
+              "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } }, "overrides": [] },
+              "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
+              "targets": [ { "refId": "A", "datasource": "Loki", "queryType": "instant", "expr": "sum(count_over_time({namespace=\"hhccia-v2\", container=\"hhccia-core\"} |= \"dead-lettering\" [1h]))" } ]
+            },
+            {
+              "id": 3, "type": "stat", "title": "Llamadas Gemini OK (15m)", "datasource": "Loki",
+              "gridPos": { "h": 4, "w": 8, "x": 16, "y": 0 },
+              "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
+              "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" },
+              "targets": [ { "refId": "A", "datasource": "Loki", "queryType": "instant", "expr": "sum(count_over_time({namespace=\"hhccia-v2\", container=\"hhccia-core\"} |= \"generativelanguage.googleapis.com\" |= \"200 OK\" [15m]))" } ]
+            },
+            {
+              "id": 4, "type": "timeseries", "title": "Gemini: errores 4xx/5xx vs éxitos en el tiempo", "datasource": "Loki",
+              "gridPos": { "h": 9, "w": 24, "x": 0, "y": 4 },
+              "fieldConfig": {
+                "defaults": { "unit": "short", "min": 0, "custom": { "drawStyle": "bars", "fillOpacity": 60, "lineWidth": 1, "stacking": { "mode": "none" } } },
+                "overrides": [
+                  { "matcher": { "id": "byFrameRefID", "options": "A" }, "properties": [ { "id": "displayName", "value": "errores 4xx/5xx" }, { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } } ] },
+                  { "matcher": { "id": "byFrameRefID", "options": "B" }, "properties": [ { "id": "displayName", "value": "éxitos (200)" }, { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } } ] }
+                ]
+              },
+              "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+              "targets": [
+                { "refId": "A", "datasource": "Loki", "queryType": "range", "expr": "sum(count_over_time({namespace=\"hhccia-v2\", container=\"hhccia-core\"} |= \"generativelanguage.googleapis.com\" |~ \"HTTP/1.1 [45]\" [$__auto]))" },
+                { "refId": "B", "datasource": "Loki", "queryType": "range", "expr": "sum(count_over_time({namespace=\"hhccia-v2\", container=\"hhccia-core\"} |= \"generativelanguage.googleapis.com\" |= \"200 OK\" [$__auto]))" }
+              ]
+            },
+            {
+              "id": 5, "type": "logs", "title": "Errores de acceso a Gemini + dead-letters (recientes)", "datasource": "Loki",
+              "gridPos": { "h": 11, "w": 24, "x": 0, "y": 13 },
+              "options": { "showTime": true, "wrapLogMessage": true, "enableLogDetails": true, "dedupStrategy": "none", "sortOrder": "Descending" },
+              "targets": [
+                { "refId": "A", "datasource": "Loki", "expr": "{namespace=\"hhccia-v2\", container=\"hhccia-core\"} |= \"generativelanguage.googleapis.com\" |~ \"HTTP/1.1 [45]\"" },
+                { "refId": "B", "datasource": "Loki", "expr": "{namespace=\"hhccia-v2\", container=\"hhccia-core\"} |= \"dead-lettering\"" }
+              ]
+            }
+          ]
+        }
 
 # Grafana-managed alerting: notify on Gemini daily spend > 6 USD. Queries the
 # GeminiCost (Postgres) datasource — Prometheus can't see the cost, it lives only

--- a/src/observability/loki-alerting-rules-configmap.yaml
+++ b/src/observability/loki-alerting-rules-configmap.yaml
@@ -1,8 +1,18 @@
-# Loki ruler alerting rules — log-based backup-failure alerts for CNPG.
+# Loki ruler alerting rules — log-based alerts.
 # Mounted into the Loki pod at /rules/fake (tenant `fake`, single-tenant Loki)
 # via singleBinary.extraVolume* in apps/observability/loki-values.yaml; the ruler
 # evaluates them and pushes to the Prometheus Alertmanager, which routes
-# severity=~"warning|critical" to Telegram.
+# severity=~"warning|critical" to Telegram. Each ConfigMap data key becomes a
+# rule file the ruler picks up, so a new group = a new data key below.
+#
+# Two rule sets:
+#   - cnpg-backup.yaml  — CNPG backup/WAL failures (see comments inline).
+#   - gemini-access.yaml — Gemini API access health for the AI core (added after
+#     the 2026-06-01 incident, where a GCP billing block then a 503 spike stalled
+#     ingestion for ~6h and NO existing alert fired — the NATS-backlog/redelivery
+#     alerts never tripped because only 4 records were ever in flight, below their
+#     >10 / >5 thresholds). This watches the core's own Gemini HTTP results so an
+#     access problem pages within ~1-2 min regardless of backlog size.
 #
 # These COMPLEMENT the metric alert CNPGWALArchivingFailing (prometheus-values):
 #   - CNPGBackupFailed: any error logged by the barman-cloud plugin sidecar — this
@@ -39,3 +49,40 @@ data:
               summary: "Postgres WAL archiving errors (hhccia-core-db)"
               description: "Postgres logged 'archive command failed' in hhccia-v2 in the last 10m — WAL archiving to R2 is failing. If sustained it breaks PITR/backups (the CNPGWALArchivingFailing metric alert escalates to critical after 15m)."
               logs: "https://logs.cjbarroso.com/d/cnpg-backup-logs?from=now-6h&to=now"
+  gemini-access.yaml: |
+    groups:
+      - name: gemini-access
+        rules:
+          # WARNING (fast heads-up): the core's calls to Gemini are returning
+          # HTTP 4xx/5xx. Catches 403 (billing/permission — the "Lightning
+          # dunning decision is deny" block seen on 2026-06-01), 429 (quota) and
+          # 503 (model overload). httpx logs one line per call:
+          #   httpx HTTP Request: POST https://generativelanguage.googleapis.com/...:generateContent "HTTP/1.1 403 Forbidden"
+          # so we match the Gemini host + a 4xx/5xx status. Threshold > 3 in 5m
+          # (not > 0) so a single transient 503 that auto-recovers on retry does
+          # NOT page — a real access problem produces dozens/min and still fires
+          # within ~1-2 min. Lower to > 0 if you want every blip. (Validated
+          # 2026-06-01: the billing+503 incident logged ~100 errors/h.)
+          - alert: GeminiAccessErrors
+            expr: sum(count_over_time({namespace="hhccia-v2", container="hhccia-core"} |= `generativelanguage.googleapis.com` |~ `HTTP/1.1 [45]` [5m])) > 3
+            labels:
+              severity: warning
+            annotations:
+              summary: "Errores de acceso a Gemini (hhccia-core)"
+              description: "El core recibió >3 respuestas HTTP 4xx/5xx desde generativelanguage.googleapis.com en los últimos 5m — falla de acceso a Gemini (403 billing/permiso, 429 cuota, 503 sobrecarga). Si se sostiene, el procesamiento IA se detiene y los registros caen a dead-letter (ver alerta GeminiRecordsDeadLettered)."
+              dashboard: "https://logs.cjbarroso.com/d/gemini-health?from=now-6h&to=now"
+              logs: "https://logs.cjbarroso.com/d/gemini-health?from=now-6h&to=now"
+          # CRITICAL (real impact): the core exhausted its retries and sent
+          # records to hhccia.records.discovered.deadletter. Ingestion is losing
+          # records right now (typically sustained Gemini failure). The adapter
+          # re-discovers from Datatech every 5m so it self-heals when Gemini
+          # recovers, but nothing persists meanwhile.
+          - alert: GeminiRecordsDeadLettered
+            expr: sum(count_over_time({namespace="hhccia-v2", container="hhccia-core"} |= `dead-lettering` [10m])) > 0
+            labels:
+              severity: critical
+            annotations:
+              summary: "Registros enviados a dead-letter — ingesta IA detenida (hhccia-core)"
+              description: "El core agotó los reintentos y envió registros a hhccia.records.discovered.deadletter en los últimos 10m: la ingesta IA está perdiendo registros, casi siempre por falla sostenida de Gemini. El adaptador re-descubre desde Datatech cada 5m (se recupera solo al volver Gemini), pero mientras tanto no se persiste nada en clinical_record."
+              dashboard: "https://logs.cjbarroso.com/d/gemini-health?from=now-6h&to=now"
+              logs: "https://logs.cjbarroso.com/d/gemini-health?from=now-6h&to=now"


### PR DESCRIPTION
## Why

The 2026-06-01 incident exposed a monitoring gap: a GCP billing block (`403` "Lightning dunning decision is deny") followed by a `503` model-overload spike stalled HHCCIA ingestion for ~6h, and **no alert fired**. The closest existing alerts (`pipeline-ingestor-backlog-gt10`, `pipeline-ingestor-redelivered`) never tripped because only 4 records were ever in flight — below their `>10` / `>5` thresholds. We need to watch the AI core's Gemini access directly so an access problem pages regardless of backlog size.

## What

**Two-tier Loki ruler alerts** (`src/observability/loki-alerting-rules-configmap.yaml`), routed to Telegram via the existing Alertmanager `severity=~"warning|critical"` route — same proven path as the CNPG/node alerts, no new secret or contact point:

- **`GeminiAccessErrors`** (warning): `>3` Gemini HTTP 4xx/5xx in 5m. Catches 403 billing/permission, 429 quota, 503 overload. `>3` (not `>0`) rides over a single transient 503 that self-heals on retry; a real outage produces dozens/min and still pages within ~1–2 min.
- **`GeminiRecordsDeadLettered`** (critical): any `records.discovered` dead-letter in 10m — ingestion is actually dropping records.

**Grafana dashboard** `gemini-health` (`apps/observability/grafana-values.yaml`): errors-vs-successes timeseries, 15m/1h stat tiles, and a recent error + dead-letter log panel. The alert Telegram messages deep-link to it via the `dashboard` annotation.

## Validation

All LogQL match strings validated against live Loki logs from the incident window (567 errors / 187 dead-letters / 5 successes). Both files pass YAML + embedded-JSON/rule parsing.

## Deploy notes

- Loki ruler `poll_interval: 1m` → the new rules load without a pod restart after Argo sync.
- Grafana re-provisions the dashboard from the rendered ConfigMap on sync.
- The one tunable knob is the `>3 in 5m` warning threshold; lower to `>0` for every blip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)