### PR TITLE
feat(hermes): deploy Hermes Agent gated by Authentik

### DIFF
--- a/apps/hermes/hermes.yaml
+++ b/apps/hermes/hermes.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hermes
+  namespace: argocd
+spec:
+  project: hermes
+  source:
+    repoURL: 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
+    path: src/hermes
+    targetRevision: master
+    directory:
+      recurse: false
+      # The placeholder secret template is never applied by Argo — the real
+      # OPENAI_API_KEY lives in hermes-secrets-sealedsecret.yaml.
+      exclude: 'secrets.example.yaml'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hermes
+  syncPolicy:
+    # Note: the deployment pins :latest, so Argo won't auto-deploy a new image
+    # (the manifest digest is unchanged) — a refresh needs a
+    # `kubectl -n hermes rollout restart deploy/hermes`.
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/projects.yaml
+++ b/apps/projects.yaml
@@ -87,3 +87,21 @@ spec:
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: hermes
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Hermes Agent
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'

--- a/src/authentik/blueprints.yaml
+++ b/src/authentik/blueprints.yaml
@@ -377,3 +377,73 @@ data:
           stage: !KeyOf signup-write-stage
           evaluate_on_plan: true
           re_evaluate_policies: false
+  # Hermes Agent — Authentik fronts the dashboard (Hermes has no native auth and
+  # exposes API keys). A PROXY provider in "proxy" mode makes the EMBEDDED OUTPOST
+  # reverse-proxy to the in-cluster Hermes service after authenticating. The public
+  # host hermes.cjbarroso.com is routed to authentik-server (the embedded outpost)
+  # in src/authentik/ingress.yaml; the outpost matches this provider by external_host.
+  #
+  # Access is gated to the `hermes-users` group (policy binding, ENABLED below).
+  # ⚠ Group MEMBERSHIP is identity data managed in the UI/DB, NOT in Git — add your
+  # own account to `hermes-users` in the admin UI or the app is inaccessible to all.
+  # (Admins still reach the admin UI regardless of this app binding.)
+  #
+  # After editing, restart the authentik worker (or wait for its discovery cycle).
+  hermes-proxy.yaml: |
+    version: 1
+    metadata:
+      name: Hermes proxy access
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_providers_proxy.proxyprovider
+        id: hermes-proxy-provider
+        identifiers:
+          name: hermes-proxy
+        attrs:
+          name: hermes-proxy
+          mode: proxy
+          external_host: https://hermes.cjbarroso.com
+          internal_host: http://hermes.hermes.svc.cluster.local:9119
+          internal_host_ssl_validation: false
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      - model: authentik_core.application
+        id: hermes-app
+        identifiers:
+          slug: hermes
+        attrs:
+          name: Hermes
+          slug: hermes
+          provider: !KeyOf hermes-proxy-provider
+          meta_launch_url: https://hermes.cjbarroso.com
+          open_in_new_tab: false
+      # Assign the proxy provider to the built-in embedded outpost so it actually
+      # serves hermes.cjbarroso.com. NOTE: this sets the embedded outpost's provider
+      # list — confirm it has no other proxy providers before applying (currently
+      # none; hhccia uses OIDC, which needs no outpost).
+      - model: authentik_outposts.outpost
+        identifiers:
+          name: authentik Embedded Outpost
+        attrs:
+          providers:
+            - !KeyOf hermes-proxy-provider
+      # Access control: only `hermes-users` members may reach Hermes. Mirrors the
+      # hhccia-users binding. Hermes can execute code/terminal/browser tools, so keep
+      # this enabled and the group membership tight.
+      - model: authentik_core.group
+        id: hermes-users-group
+        identifiers:
+          name: hermes-users
+        attrs:
+          is_superuser: false
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, hermes]]
+          group: !Find [authentik_core.group, [name, hermes-users]]
+          order: 0
+        attrs:
+          enabled: true
+          negate: false
+          timeout: 30
+          failure_result: false

--- a/src/authentik/ingress.yaml
+++ b/src/authentik/ingress.yaml
@@ -35,3 +35,19 @@ spec:
                 name: authentik-server
                 port:
                   number: 80
+    # Hermes Agent dashboard, fronted by Authentik. Hermes itself has no auth, so
+    # the public host is routed to authentik-server (the EMBEDDED OUTPOST), which
+    # matches the `hermes-proxy` proxy provider by Host (external_host
+    # https://hermes.cjbarroso.com) and reverse-proxies to the in-cluster Hermes
+    # service after authenticating. Provider + access policy live in blueprints.yaml.
+    # The cloudflared controller auto-creates the CNAME in the cjbarroso.com zone.
+    - host: "hermes.cjbarroso.com"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-server
+                port:
+                  number: 80

--- a/src/hermes/configmap.yaml
+++ b/src/hermes/configmap.yaml
@@ -1,0 +1,19 @@
+# Seed config.yaml for Hermes. The default model is NOT an env var (Hermes reads
+# it from config.yaml), so we seed it here. The init container in deployment.yaml
+# copies this into the PVC at /opt/data/config.yaml ONLY if absent, leaving the
+# file writable afterwards so the dashboard can manage settings.
+#
+# base_url + api_key are also supplied via env (OPENAI_BASE_URL / OPENAI_API_KEY);
+# they're repeated here for clarity. provider: custom + base_url makes Hermes call
+# the DeepSeek OpenAI-compatible endpoint directly.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-config-seed
+  namespace: hermes
+data:
+  config.yaml: |
+    model:
+      default: deepseek-chat
+      provider: custom
+      base_url: https://api.deepseek.com/v1

--- a/src/hermes/deployment.yaml
+++ b/src/hermes/deployment.yaml
@@ -1,0 +1,99 @@
+# Hermes Agent gateway + web dashboard. Both run as one s6-supervised process
+# tree in a single container (HERMES_DASHBOARD=1), so a single replica is correct
+# and there's no concurrent-writer problem against /opt/data.
+#
+# Recreate (not RollingUpdate): the PVC is ReadWriteOnce and Hermes owns exclusive
+# state under /opt/data — two overlapping pods would contend for the same volume.
+#
+# Auth: the dashboard has NO native auth and reads/writes API keys. We run it with
+# HERMES_DASHBOARD_INSECURE=1 (disables Hermes' own OAuth gate) and put Authentik's
+# embedded outpost in front (see src/authentik). The dashboard must therefore never
+# be exposed without that proxy.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes
+  namespace: hermes
+  labels:
+    app: hermes
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: hermes
+  template:
+    metadata:
+      labels:
+        app: hermes
+        logs.cjbarroso.com/collect: "true"   # opt in to log aggregation
+    spec:
+      automountServiceAccountToken: false
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-data
+        - name: config-seed
+          configMap:
+            name: hermes-config-seed
+      # Seed config.yaml into the PVC on first start only. Leaves the file
+      # writable so the dashboard can later edit settings; never clobbers an
+      # existing config.
+      initContainers:
+        - name: seed-config
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - '[ -f /data/config.yaml ] || cp /seed/config.yaml /data/config.yaml'
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config-seed
+              mountPath: /seed
+      containers:
+        - name: hermes
+          image: nousresearch/hermes-agent:latest
+          imagePullPolicy: Always
+          args: ["gateway", "run"]
+          env:
+            # Run the bundled web dashboard alongside the gateway.
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            # Disable Hermes' native OAuth gate — Authentik enforces auth at the
+            # edge (embedded outpost, proxy mode). Safe ONLY because the dashboard
+            # is never reachable except through that authenticated proxy.
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+            # DeepSeek via its OpenAI-compatible endpoint. The default model is set
+            # in config.yaml (seeded into the PVC); base_url + key come from here.
+            - name: OPENAI_BASE_URL
+              value: "https://api.deepseek.com/v1"
+          envFrom:
+            - secretRef:
+                name: hermes-secrets        # OPENAI_API_KEY (DeepSeek)
+          ports:
+            - name: api
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 1500m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false   # dashboard writes at runtime

--- a/src/hermes/hermes-secrets-sealedsecret.yaml
+++ b/src/hermes/hermes-secrets-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: hermes-secrets
+  namespace: hermes
+spec:
+  encryptedData:
+    OPENAI_API_KEY: AgCh+FRj2ni9jLOYYr+U9Izv1bbcjd2uoOhaV2jzwKVao33+i96twOQyf6hcbchgtwUS5m/C5nmF7TiDf/gyVa7tZqZWy14Vybz8BhCG4If7aSOk2la2okHSo74pvxIxahb2y2maEB7lLgTk5jPpPGzoe3jamFrZtTsdxPFWXv9inQqXKSsW1N2QybvzGNZdlsudjVb9w/lF/D7tIk9uR7/MukBEqrXUOYX6AvK9PBbqaT5fNK97+fVGdncE4A0sTbuY/ixVrtKFmitzN5twj7W/CmDwAgMAnrtFSXJe4HUQByrCiq5U1OvSRqMgCBN5wk2J20lPWjCSTaopQ2qsAcHykSy5iWQlIUWjYGyA4ZGAhH5QLNP5PxZ+/h8vkgiKcICxSja1uWLU53t2D/txZEkVoBBXhhx4g1a23+XZOp1qzejcYjrmgLxL+JD8nXPvMivbcm8NNQAZJ6VR9EzU+wEx11gTuUaBRY1s8h8Q2xSgryhZu0+ead5G7dXIkarWdh0Cmrhv1hjFSngqdTFRx8gFfelb+7jZZrlCeYBeBAqhCZjV2UDftCi/Q3D3N8ls/Wn20ih0GgUDS+D17x0ImvI5sTFC18uvQ3kcxfsVAv7hWjFTgbfCIIjENkETmX/XFYNq8/c+1x6BWAD1oF8uJquZD1rtIL5UitE3P8+rWhDT4T94kbw8UrDRwdxw7pLkryI=
+  template:
+    metadata:
+      name: hermes-secrets
+      namespace: hermes

--- a/src/hermes/pvc.yaml
+++ b/src/hermes/pvc.yaml
@@ -1,0 +1,15 @@
+# Durable state for Hermes Agent. Everything lives under /opt/data: config.yaml,
+# .env (API keys), sessions, memory, skills, logs. Without this volume every
+# pod restart wipes credentials and memory.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-data
+  namespace: hermes
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi

--- a/src/hermes/secrets.example.yaml
+++ b/src/hermes/secrets.example.yaml
@@ -1,0 +1,17 @@
+# PLACEHOLDER secret — DO NOT COMMIT REAL VALUES.
+#
+# The real secret is committed as a SealedSecret (hermes-secrets-sealedsecret.yaml).
+# This file documents the expected shape only and is intentionally NOT applied by
+# Argo (the hermes app excludes it via the directory exclude).
+#
+# OPENAI_API_KEY is the DeepSeek API key — Hermes uses it to authenticate against
+# the OpenAI-compatible endpoint configured in OPENAI_BASE_URL (see deployment.yaml
+# / configmap.yaml).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-secrets
+  namespace: hermes
+type: Opaque
+stringData:
+  OPENAI_API_KEY: "REPLACE_ME"

--- a/src/hermes/service.yaml
+++ b/src/hermes/service.yaml
@@ -1,0 +1,21 @@
+# ClusterIP only. The dashboard (9119) is reached via the Authentik embedded
+# outpost (proxy mode) — see src/authentik. The gateway API (8642) stays internal;
+# reach it with `kubectl -n hermes port-forward svc/hermes 8642:8642` if needed.
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes
+  namespace: hermes
+spec:
+  type: ClusterIP
+  selector:
+    app: hermes
+  ports:
+    - name: api
+      port: 8642
+      targetPort: api
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
+      protocol: TCP


### PR DESCRIPTION
## What

Adds **Hermes Agent** (`nousresearch/hermes-agent`) as a new Argo CD app in the `hermes` namespace, following the `src/<app>` + `apps/<app>` pattern (like hhccia-v2).

- New `hermes` AppProject + Argo Application (`src/hermes`, auto-sync, `CreateNamespace`).
- **Deployment**: single replica, `Recreate`; gateway + dashboard run in one container (`HERMES_DASHBOARD=1`). **10Gi local-path PVC** at `/opt/data` persists config, sessions, memory, skills. initContainer seeds `config.yaml` once (kept writable).
- **LLM**: DeepSeek via OpenAI-compatible endpoint (`OPENAI_BASE_URL`) + `OPENAI_API_KEY` from a **SealedSecret**; default model `deepseek-chat` set in `config.yaml`.
- **Public access** at `hermes.cjbarroso.com` fronted by **Authentik**: the dashboard has no native auth and exposes API keys, so it runs `HERMES_DASHBOARD_INSECURE=1` and Authentik's **embedded outpost (proxy mode)** authenticates in front of it. Access gated to a new **`hermes-users`** group via a policy binding.

## Post-merge manual steps

1. `kubectl -n authentik rollout restart deploy/authentik-worker` — apply the new blueprint (creates the proxy provider, app, outpost assignment, group + binding).
2. **Add your account to `hermes-users`** in the Authentik admin UI, or the gate locks everyone out.

## Verify

- `kubectl -n hermes get pods,pvc,svc`; port-forward 9119 and send a test chat (DeepSeek responds); public host redirects through Authentik; pod restart preserves state.
- Confirm the embedded outpost's only provider is `hermes-proxy`.
- Watch-item: dashboard WebSocket through the proxy (Hermes issue #35322).

🤖 Generated with [Claude Code](https://claude.com/claude-code)