### PR TITLE
feat(hermes): enable Telegram gateway

### DIFF
--- a/src/hermes/deployment.yaml
+++ b/src/hermes/deployment.yaml
@@ -74,6 +74,14 @@ spec:
             # in config.yaml (seeded into the PVC); base_url + key come from here.
             - name: OPENAI_BASE_URL
               value: "https://api.deepseek.com/v1"
+            # Telegram messaging gateway (long-polling — outbound only, no ingress).
+            # TELEGRAM_BOT_TOKEN arrives via the envFrom secret below; token + this
+            # allowlist together activate the platform on `gateway run`. We inject
+            # via env (not `hermes gateway setup`) so the config survives pod
+            # restarts — interactive setup writes to the exec session's HOME, not
+            # the PVC. Allowlist is REQUIRED: without it the gateway denies everyone.
+            - name: TELEGRAM_ALLOWED_USERS
+              value: "1142335836"
           envFrom:
             - secretRef:
                 name: hermes-secrets        # OPENAI_API_KEY (DeepSeek)

--- a/src/hermes/hermes-secrets-sealedsecret.yaml
+++ b/src/hermes/hermes-secrets-sealedsecret.yaml
@@ -1,13 +1,20 @@
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: hermes-secrets
-  namespace: hermes
-spec:
-  encryptedData:
-    OPENAI_API_KEY: AgCh+FRj2ni9jLOYYr+U9Izv1bbcjd2uoOhaV2jzwKVao33+i96twOQyf6hcbchgtwUS5m/C5nmF7TiDf/gyVa7tZqZWy14Vybz8BhCG4If7aSOk2la2okHSo74pvxIxahb2y2maEB7lLgTk5jPpPGzoe3jamFrZtTsdxPFWXv9inQqXKSsW1N2QybvzGNZdlsudjVb9w/lF/D7tIk9uR7/MukBEqrXUOYX6AvK9PBbqaT5fNK97+fVGdncE4A0sTbuY/ixVrtKFmitzN5twj7W/CmDwAgMAnrtFSXJe4HUQByrCiq5U1OvSRqMgCBN5wk2J20lPWjCSTaopQ2qsAcHykSy5iWQlIUWjYGyA4ZGAhH5QLNP5PxZ+/h8vkgiKcICxSja1uWLU53t2D/txZEkVoBBXhhx4g1a23+XZOp1qzejcYjrmgLxL+JD8nXPvMivbcm8NNQAZJ6VR9EzU+wEx11gTuUaBRY1s8h8Q2xSgryhZu0+ead5G7dXIkarWdh0Cmrhv1hjFSngqdTFRx8gFfelb+7jZZrlCeYBeBAqhCZjV2UDftCi/Q3D3N8ls/Wn20ih0GgUDS+D17x0ImvI5sTFC18uvQ3kcxfsVAv7hWjFTgbfCIIjENkETmX/XFYNq8/c+1x6BWAD1oF8uJquZD1rtIL5UitE3P8+rWhDT4T94kbw8UrDRwdxw7pLkryI=
-  template:
-    metadata:
-      name: hermes-secrets
-      namespace: hermes
+{
+  "kind": "SealedSecret",
+  "apiVersion": "bitnami.com/v1alpha1",
+  "metadata": {
+    "name": "hermes-secrets",
+    "namespace": "hermes"
+  },
+  "spec": {
+    "template": {
+      "metadata": {
+        "name": "hermes-secrets",
+        "namespace": "hermes"
+      }
+    },
+    "encryptedData": {
+      "OPENAI_API_KEY": "AgCh+FRj2ni9jLOYYr+U9Izv1bbcjd2uoOhaV2jzwKVao33+i96twOQyf6hcbchgtwUS5m/C5nmF7TiDf/gyVa7tZqZWy14Vybz8BhCG4If7aSOk2la2okHSo74pvxIxahb2y2maEB7lLgTk5jPpPGzoe3jamFrZtTsdxPFWXv9inQqXKSsW1N2QybvzGNZdlsudjVb9w/lF/D7tIk9uR7/MukBEqrXUOYX6AvK9PBbqaT5fNK97+fVGdncE4A0sTbuY/ixVrtKFmitzN5twj7W/CmDwAgMAnrtFSXJe4HUQByrCiq5U1OvSRqMgCBN5wk2J20lPWjCSTaopQ2qsAcHykSy5iWQlIUWjYGyA4ZGAhH5QLNP5PxZ+/h8vkgiKcICxSja1uWLU53t2D/txZEkVoBBXhhx4g1a23+XZOp1qzejcYjrmgLxL+JD8nXPvMivbcm8NNQAZJ6VR9EzU+wEx11gTuUaBRY1s8h8Q2xSgryhZu0+ead5G7dXIkarWdh0Cmrhv1hjFSngqdTFRx8gFfelb+7jZZrlCeYBeBAqhCZjV2UDftCi/Q3D3N8ls/Wn20ih0GgUDS+D17x0ImvI5sTFC18uvQ3kcxfsVAv7hWjFTgbfCIIjENkETmX/XFYNq8/c+1x6BWAD1oF8uJquZD1rtIL5UitE3P8+rWhDT4T94kbw8UrDRwdxw7pLkryI=",
+      "TELEGRAM_BOT_TOKEN": "AgCMKxH2vJi0sEmi+MB+vf6smAh3oA2tnqAFIL+k3tF46hOHr2RCJpQQxAd3Y17OhAdlLioEfeZkm2L6FsNJ4/B3qr+Nx9o2ihgLOzaH+sQD49HIM7VFmyP1tFXi/hr8DNexJCOH9gX4CZELxdEIRMrlh8yiQInFZe+Luw7fr2TGec/zD+U892w5AZEr6GwsuTQbkRbr4hOCbVxWRJeE27DRK0/vMO6Ach1oPphXHxquTVF+Q2c1FFmLmTYAJeBVzXJhsgK6Y3eEhpqqzEsNvLOsMeE9ZB85P0idxRpLwoJ27gOicnPYjf7IcnfJahuwFQ1/C14N5/9AqISzuuUlk86YtbOnMrkG1y3acy5WKmJ6cFoM6/ITxwc5kjYlmWOxT/T8Nz6gjn7JlFbyWsHz7M1cZd+F6NW7yCVn0LTUmrDcTTrad0v3O+/IGoaeYIxyohJXag+ySwl436snxiSw8yjChPYsGJwUEbKGAl8e5N9pdmhknEC0jGkveDOlgoUbxgqcEgY7w06SXKTSj1UJUL/HltpqgSS+qXgMufHAV4DjgKFjIj/vZgLxyOX+vUdA1xbgqkURFCY8DcM6pwdqGuqdXRYKSGq7so6dlNzMTP1kcapHf5/FbDz9NGFDX8hHqaGPejE2aMbJ36Duc8glAVQKxNyHzs3DuF6dBiUwgTK5KDzChTHBi1jM3p1CM0/+KlSDOZ6w849ISwPf1/oDsErO2sgHZUgj58rQ5TfCAV9ndMVavw=="
+    }
+  }
+}


### PR DESCRIPTION
Enables the Telegram messaging gateway for Hermes.

- `TELEGRAM_BOT_TOKEN` merged into the `hermes-secrets` SealedSecret (delivered via the existing `envFrom`).
- `TELEGRAM_ALLOWED_USERS` set as a Deployment env (required allowlist).

Long-polling mode → outbound only, no ingress/webhook. Configured via env (not `hermes gateway setup`, which writes to the exec session's ephemeral HOME) so it persists across pod restarts.

After merge: Argo rolls out; verify with `kubectl -n hermes logs deploy/hermes -c hermes` and a DM to the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)