### PR TITLE
chore: low-risk image/chart version bumps (cert-manager, cloudflared, nats, alpine)

### DIFF
--- a/apps/cert-manager-app.yaml
+++ b/apps/cert-manager-app.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://charts.jetstack.io
     chart: cert-manager
-    targetRevision: "1.19.1"
+    targetRevision: "1.20.2"
     helm:
       values: |
         installCRDs: true

--- a/apps/operators/cloudflared/cloudflared-operator.yaml
+++ b/apps/operators/cloudflared/cloudflared-operator.yaml
@@ -7,7 +7,7 @@ spec:
   sources:
   - repoURL: https://helm.strrl.dev
     chart: cloudflare-tunnel-ingress-controller
-    targetRevision: 0.0.21
+    targetRevision: 0.0.23
     helm:
       valueFiles:
       - $values/manifests/operators/cloudflared/cloudflared-values-production.yaml

--- a/src/hhccia-v2/nats-exporter.yaml
+++ b/src/hhccia-v2/nats-exporter.yaml
@@ -30,7 +30,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: exporter
-          image: natsio/prometheus-nats-exporter:0.16.0
+          image: natsio/prometheus-nats-exporter:0.19.1
           # -jsz=all exposes JetStream stream + consumer metrics; the positional
           # arg is the NATS monitoring URL (port 8222, not the 4222 client port).
           args: ["-port=7777", "-jsz=all", "http://nats:8222"]

--- a/src/hhccia-v2/nats.yaml
+++ b/src/hhccia-v2/nats.yaml
@@ -22,7 +22,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: nats
-          image: nats:2.10-alpine
+          image: nats:2.14-alpine
           args: ["-js", "-sd", "/data", "-m", "8222"]
           ports:
             - { containerPort: 4222, name: client }

--- a/src/vaultwarden/vaultwarden-sqlite-backup-cronjob.yaml
+++ b/src/vaultwarden/vaultwarden-sqlite-backup-cronjob.yaml
@@ -33,7 +33,7 @@ spec:
             runAsUser: 0            # root: install sqlite + read the nobody-owned DB
           containers:
             - name: sqlite-backup
-              image: alpine:3.20
+              image: alpine:3.22
               command:
                 - /bin/sh
                 - -c


### PR DESCRIPTION
Low-risk image/chart version bumps from the GitOps version audit (2026-06-03). Each is a clean minor/patch with no config-breaking changes; verified against upstream release notes.

- **cert-manager** chart `1.19.1 → 1.20.2` — reverts the 1.19.0 API-default change that caused spurious cert renewals; `installCRDs` unchanged.
- **cloudflared** (cloudflare-tunnel-ingress-controller) chart `0.0.21 → 0.0.23` — patch.
- **nats** image `2.10-alpine → 2.14-alpine` + **prometheus-nats-exporter** `0.16.0 → 0.19.1` — JetStream is emptyDir/test-grade, monitoring flags unchanged.
- **vaultwarden** backup CronJob **alpine** `3.20 → 3.22` — just `apk add sqlite`.

Branched off `origin/master` deliberately to avoid entangling an unrelated in-flight authentik commit. The higher-risk bumps from the same audit (velero major, cnpg operator, grafana/loki community-fork migration) are intentionally **not** here — they need a maintenance window / separate review.