### PR TITLE
chore: window version bumps (velero major, cnpg operator, grafana/loki community-fork migration)

### DIFF
--- a/apps/observability/grafana.yaml
+++ b/apps/observability/grafana.yaml
@@ -8,10 +8,15 @@ metadata:
 spec:
   project: support
   sources:
-    - repoURL: https://grafana.github.io/helm-charts
+    # Migrated to the community fork (2026-06-03): the official grafana/grafana
+    # chart froze on 2026-01-30; OSS updates continue in grafana-community.
+    - repoURL: https://grafana-community.github.io/helm-charts
       chart: grafana
-      # Pinned + validated with `helm template` (2026-05-29). app Grafana 12.3.1.
-      targetRevision: "10.5.15"
+      # Pinned + validated with `helm template` against grafana-values.yaml (2026-06-03):
+      # renders clean (ingress, provisioned datasources, BigQuery WIF mounts, Gemini +
+      # pipeline alerting all intact). app Grafana 13.0.1 (server major 12->13; SQLite
+      # schema migrates one-way on first boot — rollback = restore the PVC).
+      targetRevision: "12.4.2"
       helm:
         valueFiles:
           - $values/apps/observability/grafana-values.yaml

--- a/apps/observability/loki-values.yaml
+++ b/apps/observability/loki-values.yaml
@@ -1,8 +1,12 @@
-# Loki Helm values — Monolithic (SingleBinary), filesystem, 30-day retention.
+# Loki Helm values — Monolithic, filesystem, 30-day retention.
 # Kept deliberately minimal/light. Extra disable-flags are over-specified on
 # purpose: Helm ignores unknown value keys, so this survives minor chart drift.
-
-deploymentMode: SingleBinary
+#
+# Community chart (grafana-community/loki, fork of the frozen grafana/loki OSS
+# chart): the deploymentMode value `SingleBinary` was renamed to `Monolithic`
+# at community chart 12.0.0. The config block below is still `singleBinary:`
+# (the chart did NOT rename the block) — Monolithic mode reads from it.
+deploymentMode: Monolithic
 
 loki:
   auth_enabled: false           # single-tenant; no X-Scope-OrgID needed

--- a/apps/observability/loki.yaml
+++ b/apps/observability/loki.yaml
@@ -12,12 +12,15 @@ metadata:
 spec:
   project: support
   sources:
-    - repoURL: https://grafana.github.io/helm-charts
+    # Migrated to the community fork (2026-06-03): the OSS Loki chart moved to
+    # grafana-community/helm-charts on 2026-03-16; grafana/loki is now GEL-only.
+    - repoURL: https://grafana-community.github.io/helm-charts
       chart: loki
-      # Pinned + validated with `helm template` (2026-05-29). 7.0.0 still accepts
-      # `deploymentMode: SingleBinary` (verified); the community fork renames it to
-      # `Monolithic` only at 12.x — if you bump past the fork, switch the values key.
-      targetRevision: "7.0.0"
+      # Pinned + validated with `helm template` against loki-values.yaml (2026-06-03):
+      # renders exactly one Monolithic StatefulSet, ruler + rule mounts intact, no
+      # read/write/backend Deployments. deploymentMode renamed SingleBinary->Monolithic
+      # (community 12.0.0) — done in loki-values.yaml. Loki server appVersion 3.7.2.
+      targetRevision: "17.1.6"
       helm:
         valueFiles:
           - $values/apps/observability/loki-values.yaml

--- a/apps/operators/cnpg/cloudnativepg-operator.yaml
+++ b/apps/operators/cnpg/cloudnativepg-operator.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://cloudnative-pg.github.io/charts
     chart: cloudnative-pg
-    targetRevision: "0.26.1" # Use a specific chart version
+    targetRevision: "0.28.2" # operator appVersion 1.29.0 (was 0.26.1). NB: operator upgrade rolls the PG instances.
   destination:
     server: https://kubernetes.default.svc
     namespace: cnpg-system

--- a/apps/velero/values-production.yaml
+++ b/apps/velero/values-production.yaml
@@ -2,7 +2,7 @@ deployNodeAgent: true
 
 initContainers:
   - name: velero-plugin-for-aws
-    image: velero/velero-plugin-for-aws:v1.10.0
+    image: velero/velero-plugin-for-aws:v1.14.1
     volumeMounts:
       - mountPath: /target
         name: plugins
@@ -72,9 +72,8 @@ schedules:
                   onError: Continue   # never let a hook failure abort the FS backup
                   timeout: 10m
 
-upgradeCRDs: false # Do not upgrade CRDs. Fixes installation issues.
-kubectl:
-  image:
-    repository: docker.io/bitnami/kubectl
-    tag: latest
-    pullPolicy: IfNotPresent
+# CRDs are applied directly by Argo (helm rendered with --include-crds), so the
+# chart's CRD-upgrade hook-job stays off. The old docker.io/bitnami/kubectl:latest
+# override was removed — Bitnami's public catalog was sunset; chart 12.x defaults
+# the kubectl image to registry.k8s.io/kubectl.
+upgradeCRDs: false

--- a/apps/velero/velero-app.yaml
+++ b/apps/velero/velero-app.yaml
@@ -9,7 +9,7 @@ spec:
   # Source 1: Official Velero Helm Chart
   - chart: velero
     repoURL: https://vmware-tanzu.github.io/helm-charts
-    targetRevision: 11.2.0 # Check for latest stable version
+    targetRevision: 12.0.2 # Velero server appVersion 1.18.1 (was 11.2.0 / 1.17.1)
     helm:
       valueFiles:
       # References the file in Source 2
@@ -30,3 +30,6 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # Velero 1.18 CRDs are large; client-side apply hits the 262KB annotation
+      # limit. SSA applies them cleanly (Argo renders helm with --include-crds).
+      - ServerSideApply=true


### PR DESCRIPTION
Higher-impact bumps from the GitOps version audit (2026-06-03), deliberately separated from the low-risk batch (#38) for a controlled window. All validated against upstream release notes; the two Helm-chart migrations were validated with `helm template` against the live values files.

### cnpg
- operator chart `0.26.1 → 0.28.2` (operator appVersion 1.29.0). **Triggers a rolling restart of the `hhccia-core-db` instances → brief failover.**

### velero
- chart `11.2.0 → 12.0.2` (Velero server `1.17.1 → 1.18.1`)
- plugin `v1.10.0 → v1.14.1` (the v1.14.x line targets Velero 1.18; the previously-pinned v1.10.0 was 3 minors behind the running server)
- removed the now-defunct `docker.io/bitnami/kubectl:latest` override (Bitnami public catalog sunset; chart 12.x defaults to `registry.k8s.io/kubectl`)
- added `ServerSideApply=true` so the large 1.18 CRDs apply cleanly
- **Verify a backup runs green after sync.**

### observability (grafana + loki → grafana-community fork)
- grafana chart `10.5.15 → 12.4.2` (Grafana server `~12.3 → 13.0.1`; **SQLite schema migrates one-way on first boot — rollback = restore the 2Gi PVC**)
- loki chart `7.0.0 → 17.1.6` (Loki server 3.7.2); `deploymentMode: SingleBinary → Monolithic` (community 12.0.0 rename)
- both old `grafana/helm-charts` chart lines froze for OSS in early 2026
- renders verified: loki = 1 Monolithic StatefulSet with ruler rule-mounts intact; grafana = ingress + provisioned datasources + BigQuery WIF + Gemini/pipeline alerting all intact