### PR TITLE
fix(velero): pin plugin v1.13.0 for Cloudflare R2 compatibility

### DIFF
--- a/apps/velero/values-production.yaml
+++ b/apps/velero/values-production.yaml
@@ -2,7 +2,14 @@ deployNodeAgent: true
 
 initContainers:
   - name: velero-plugin-for-aws
-    image: velero/velero-plugin-for-aws:v1.14.1
+    # Pinned to v1.13.0, NOT the v1.14.x that matches velero 1.18: v1.14 bumped
+    # aws-sdk-go-v2 (s3 v1.48.0 -> v1.97.3), and the newer SDK emits an empty
+    # `x-amz-tagging` header on PutObject that Cloudflare R2 rejects (501
+    # NotImplemented) — breaking backup-metadata upload. v1.13.0 is the newest
+    # plugin still on the R2-compatible s3 v1.48.0 SDK (same as the long-working
+    # v1.10.0). 1-minor skew under server 1.18.1, fine for object-store ops
+    # (we previously ran v1.10.0 under 1.17.1 — a 3-minor skew — without issue).
+    image: velero/velero-plugin-for-aws:v1.13.0
     volumeMounts:
       - mountPath: /target
         name: plugins


### PR DESCRIPTION
**Fixes the R2 backup regression from #39.** velero-plugin-for-aws **v1.14.1** (the version matching velero 1.18) bumped aws-sdk-go-v2 (`s3 v1.48.0 → v1.97.3`); the newer SDK serializes an empty **`x-amz-tagging`** header on `PutObject`, which Cloudflare R2 rejects (`501 NotImplemented`) — so backup *metadata* uploads fail and backups are non-restorable (volume data via kopia is unaffected).

**Fix:** pin the plugin to **`v1.13.0`** — the newest release still on the R2-compatible `s3 v1.48.0` SDK (identical to the long-working v1.10.0). The plugin's tagging code is identical across versions; only the SDK differs. Keeps velero **server 1.18.1** (1-minor plugin skew — we previously ran a 3-minor skew, v1.10.0 under 1.17.1, without issue).

Verified by go.mod diff across v1.10.0 / v1.12.2 / v1.13.0 / v1.14.1. Will re-run an on-demand backup post-merge to confirm `Completed`.