### PR TITLE
feat: add second Hermes instance (hermes2, Hannibal/Discord)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        # This repo uses multi-document YAML (e.g. apps/projects.yaml,
+        # src/*/networkpolicies.yaml). Without this flag check-yaml rejects any
+        # file containing more than one `---` document.
+        args: [--allow-multiple-documents]
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.24.3
     hooks:

--- a/apps/hermes2/app.yaml
+++ b/apps/hermes2/app.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hermes2
+  namespace: argocd
+spec:
+  project: hermes2
+  source:
+    repoURL: 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
+    path: src/hermes2
+    targetRevision: master
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hermes2
+  syncPolicy:
+    # The deployment pins an upstream release tag + digest — upgrades are a
+    # tag/digest bump in src/hermes2/deployment.yaml; Argo rolls it on sync.
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/projects.yaml
+++ b/apps/projects.yaml
@@ -117,3 +117,19 @@ spec:
     - { server: 'https://kubernetes.default.svc', namespace: hermes }
   clusterResourceWhitelist:
     - { group: '', kind: Namespace }
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: hermes2
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Hermes Agent — second instance (Hannibal/Discord). Independent of the hermes project.
+  sourceRepos:
+    - 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
+  destinations:
+    - { server: 'https://kubernetes.default.svc', namespace: hermes2 }
+  clusterResourceWhitelist:
+    - { group: '', kind: Namespace }

--- a/src/hermes2/deployment.yaml
+++ b/src/hermes2/deployment.yaml
@@ -1,0 +1,82 @@
+# SECOND Hermes Agent instance (Hannibal/Discord). Independent of src/hermes —
+# its own namespace, PVC, service and Argo app. Does NOT touch instance #1.
+#
+# Source of truth = the PVC (/opt/data). Hermes owns its own config.yaml, .env
+# (API keys, Discord bot token), sessions, memory and skills there. Git only
+# defines the WORKLOAD — no app config/secrets via env/ConfigMap/Secret. The
+# hannibal operating layer (profiles, profile_router.yaml, projects/) is copied
+# onto /opt/data after first boot (see deploy notes), then real Discord IDs +
+# tokens are entered via the dashboard / `hermes gateway setup`.
+#
+# Recreate (not RollingUpdate): RWO PVC, single owner of /opt/data.
+#
+# Auth: the dashboard has NO native auth and exposes API keys, so it runs with
+# HERMES_DASHBOARD_INSECURE=1. Unlike instance #1 there is NO Authentik proxy
+# in front — this instance has no Ingress and is reachable only via
+# `kubectl -n hermes2 port-forward` (localhost, gated by kube RBAC). Never add
+# an Ingress without putting auth in front first.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes2
+  namespace: hermes2
+  labels:
+    app: hermes2
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: hermes2
+  template:
+    metadata:
+      labels:
+        app: hermes2
+        logs.cjbarroso.com/collect: "true"   # opt in to log aggregation
+    spec:
+      automountServiceAccountToken: false
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes2-data
+      containers:
+        - name: hermes
+          # Pinned to the same upstream release tag + manifest digest as
+          # instance #1 (immutable). To upgrade: pick a newer vYYYY.M.D tag from
+          # Docker Hub, update tag AND digest. Bump the two instances independently.
+          image: nousresearch/hermes-agent:v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
+          imagePullPolicy: IfNotPresent
+          args: ["gateway", "run"]
+          env:
+            # Run the bundled web dashboard alongside the gateway, bound on all
+            # interfaces with its native OAuth gate OFF. Only reachable via
+            # port-forward (no Ingress, default-deny-ingress NetworkPolicy).
+            - name: HERMES_DASHBOARD
+              value: "1"
+            - name: HERMES_DASHBOARD_HOST
+              value: "0.0.0.0"
+            - name: HERMES_DASHBOARD_PORT
+              value: "9119"
+            - name: HERMES_DASHBOARD_INSECURE
+              value: "1"
+          ports:
+            - name: api
+              containerPort: 8642
+              protocol: TCP
+            - name: dashboard
+              containerPort: 9119
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 1500m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false   # dashboard + gateway write at runtime

--- a/src/hermes2/networkpolicies.yaml
+++ b/src/hermes2/networkpolicies.yaml
@@ -1,0 +1,51 @@
+# Network segmentation for the hermes2 namespace (second Hermes instance —
+# Hannibal/Discord). This instance has NO public ingress: the dashboard is
+# reached only via `kubectl -n hermes2 port-forward` (see service.yaml). There
+# is therefore no Authentik-outpost ingress allowance here (unlike src/hermes).
+# Discord is reached as EGRESS (gateway websocket), unrestricted for now.
+#
+# Mirrors the src/hermes pattern minus the authentik ingress rule.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes2
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: hermes2
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: hermes2
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - podSelector: {}
+---
+# Kubelet probes + `kubectl port-forward` reach the pod from the node. Without
+# this the dashboard/API port-forward (the only access path for this instance)
+# would be blocked by default-deny-ingress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kubelet-probes
+  namespace: hermes2
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - ipBlock: { cidr: 10.42.0.1/32 }

--- a/src/hermes2/pvc.yaml
+++ b/src/hermes2/pvc.yaml
@@ -1,0 +1,17 @@
+# Durable state for the SECOND Hermes instance. Everything lives under /opt/data:
+# config.yaml, .env (API keys, Discord bot token), sessions, memory, skills, logs.
+# This is the volume the hannibal-deployment config is copied onto (see
+# src/hermes2/README or the deploy runbook). Separate from hermes-data — the two
+# instances never share state. Backed up by Velero like the rest of the cluster.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes2-data
+  namespace: hermes2
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi

--- a/src/hermes2/service.yaml
+++ b/src/hermes2/service.yaml
@@ -1,0 +1,25 @@
+# ClusterIP only, NO ingress. Unlike src/hermes (fronted by Authentik), this
+# second instance is not publicly exposed. Reach the dashboard or gateway API
+# locally with port-forward:
+#   kubectl -n hermes2 port-forward svc/hermes2 9119:9119   # dashboard
+#   kubectl -n hermes2 port-forward svc/hermes2 8642:8642   # gateway API
+# Do NOT add an Ingress to this service without putting Authentik (or equivalent
+# auth) in front — the dashboard has no native auth and exposes API keys.
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes2
+  namespace: hermes2
+spec:
+  type: ClusterIP
+  selector:
+    app: hermes2
+  ports:
+    - name: api
+      port: 8642
+      targetPort: api
+      protocol: TCP
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
+      protocol: TCP


### PR DESCRIPTION
## What

Stands up an **independent second Hermes instance** (`hermes2`) via GitOps to host the Hannibal/Discord operating layer (profiles + router + project memory from the private `hannibal-deployment` repo). **Instance #1 is untouched.**

## Resources (all new under `hermes2`)

- `apps/hermes2/app.yaml` — ArgoCD Application, project `hermes2`, syncs `src/hermes2/` into ns `hermes2`
- `apps/projects.yaml` — **appends** AppProject `hermes2` (existing `hermes` project unchanged)
- `src/hermes2/networkpolicies.yaml` — ns `hermes2` (PSS labels) + default-deny-ingress + intra-ns + kubelet/port-forward
- `src/hermes2/pvc.yaml` — `hermes2-data`, 10Gi RWO local-path
- `src/hermes2/service.yaml` — ClusterIP, selector `app: hermes2`, **no ingress**
- `src/hermes2/deployment.yaml` — same pinned image+digest as #1, `Recreate`, dashboard `INSECURE` (port-forward only)

## Design notes

- **Own namespace + own AppProject** → full isolation; never touches `hermes` ns/PVC/Authentik.
- **No public ingress** → the dashboard has no native auth and exposes API keys; fronting it would mean editing instance #1's shared Authentik config. Reachable only via `kubectl -n hermes2 port-forward`.
- **Separate PVC** → no shared state; Velero backs it up.
- Also enables `--allow-multiple-documents` on the `check-yaml` pre-commit hook (the repo uses multi-doc YAML).

## Post-merge runtime steps (not GitOps)

1. Argo's root app auto-discovers `apps/hermes2/` and syncs the workload.
2. Copy the hannibal config onto `hermes2-data` (`kubectl cp config.yaml/profile_router.yaml/profiles/projects` → `/opt/data`).
3. Enter the Discord bot token + channel IDs via the dashboard; `hermes gateway setup`; reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)