### PR TITLE
deploy(hhccia-v2): pin core+front to voice_enabled-gating builds

### DIFF
--- a/src/hhccia-v2/hhccia-core.yaml
+++ b/src/hhccia-v2/hhccia-core.yaml
@@ -36,7 +36,7 @@ spec:
         - name: hhccia-core
           # Pinned to the git SHA of the last successful publish run (main).
           # To deploy a new build: update this tag to the new commit SHA and let Argo sync.
-          image: ghcr.io/irupe-consultores/hhccia-core:712986bb653110af93ddcc580b8b44ef8f7c0c09
+          image: ghcr.io/irupe-consultores/hhccia-core:d3c2f0dc6640463efac4f3aa84f419f63eb6471f
           imagePullPolicy: IfNotPresent
           ports:
             - { containerPort: 8000, name: http }

--- a/src/hhccia-v2/hhccia-front.yaml
+++ b/src/hhccia-v2/hhccia-front.yaml
@@ -29,7 +29,7 @@ spec:
         - name: hhccia-front
           # Pinned to the git SHA of the last successful publish run (main).
           # To deploy a new build: update this tag to the new commit SHA and let Argo sync.
-          image: ghcr.io/irupe-consultores/hhccia-front:f4701c9ea1736f2aef27fb6acdde0431f9cc910c
+          image: ghcr.io/irupe-consultores/hhccia-front:31fd4f8583383b8e24ec05614a66875c6d7a9d90
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Bumps the hhccia-v2 image tags to the merges that gate dictation on the `voice_enabled` claim:
- core → `d3c2f0d` (hhccia-core#22)
- front → `31fd4f8` (hhccia-front#22)

Authentik side (group `hhccia-voice-enabled` + `voice_enabled` claim) already live via #54. Build workflows for both SHAs completed successfully (images pushed to GHCR).

⚠️ Fail-closed cutover: dictation disabled until users are added to `hhccia-voice-enabled` + re-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)