### PR TITLE
feat(planka): allow hermes2 ns ingress to web pods for API access

### DIFF
--- a/src/planka/networkpolicies.yaml
+++ b/src/planka/networkpolicies.yaml
@@ -69,6 +69,25 @@ spec:
       ports:
         - { protocol: TCP, port: 1337 }
 ---
+# The hermes2 agent calls the Planka REST API (X-Api-Key auth) over the internal
+# Service, so it needs ingress to the web pods on 1337 — same scope as the tunnel
+# (web pods only, never Postgres directly). hermes2's own namespace has no egress
+# policy, so no rule is needed there; this ingress allow is the only change.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-hermes2-to-web
+  namespace: planka
+spec:
+  podSelector:
+    matchLabels: { app.kubernetes.io/name: planka }
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { kubernetes.io/metadata.name: hermes2 }
+      ports:
+        - { protocol: TCP, port: 1337 }
+---
 # Prometheus scrapes the CNPG instance metrics.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
Lets the **hermes2** agent call the Planka REST API (`X-Api-Key`) over the internal Service `planka.planka.svc:1337`.

The `planka` namespace is default-deny-ingress and only `cloudflared` could reach the web pods, so this adds `allow-hermes2-to-web` — ingress from the `hermes2` namespace to pods `app.kubernetes.io/name=planka` on TCP 1337. Mirrors the existing `allow-tunnel-to-web` (web pods only, never Postgres). hermes2's own namespace has no egress policy, so no rule is needed there.

Part of giving hermes2 programmatic Planka access via a per-user API key (key lives on the hermes2 PVC `.env`, not a K8s Secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)