### PR TITLE
fix(hermes2): raise memory limit 2Gi->3Gi for MCP npx installs

### DIFF
--- a/src/hermes2/deployment.yaml
+++ b/src/hermes2/deployment.yaml
@@ -80,7 +80,12 @@ spec:
               memory: 512Mi
             limits:
               cpu: 1500m
-              memory: 2Gi
+              # 3Gi (was 2Gi): the gateway sits at ~900Mi, and adding an MCP
+              # server via `npx` (e.g. @chmald/planka-mcp) spikes memory during
+              # the first install — at 2Gi the container OOMKilled (exit 137).
+              # Steady state with the MCP running is ~1Gi; 3Gi covers the install
+              # spike + resident node process. Node has headroom (~5Gi free / 14Gi).
+              memory: 3Gi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false   # dashboard + gateway write at runtime


### PR DESCRIPTION
Adding a Planka MCP server via `hermes mcp add` (which runs `npx @chmald/planka-mcp`) spiked memory on top of the ~900Mi gateway and **OOMKilled the container at the 2Gi limit** (exit 137), restarting the Discord agent.

Steady state with the MCP server running is ~1Gi; **3Gi** covers the first-install spike plus the resident node process. The `homestation` node has headroom (~5Gi free of 14Gi; limits already overcommitted but actual usage at 64%).

Unblocks wiring Planka into hermes2 (per-user API key via `@chmald/planka-mcp`, reachable over the internal Service thanks to PR #57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)