### PR TITLE
hhccia-core: env para self-service de perfil (Authentik API)

### DIFF
--- a/src/hhccia-v2/hhccia-core.yaml
+++ b/src/hhccia-v2/hhccia-core.yaml
@@ -69,6 +69,23 @@ spec:
             # (the public URL); JWKS is just how we fetch the signing keys.
             - name: AUTHENTIK_JWKS_URL
               value: "http://authentik-server.authentik.svc.cluster.local/application/o/hhccia/jwks/"
+            # Self-service user preferences (PATCH /me/profile) writes the user's
+            # own name/prf/service back to Authentik via its MANAGEMENT API (the
+            # reverse direction of the JWKS validation above). AUTHENTIK_API_TOKEN
+            # is a service-account token scoped to core.view_user + core.change_user,
+            # sealed into hhccia-core-secrets. `optional: true` so the pod still boots
+            # BEFORE the token is sealed — until then /me/profile is read-only and a
+            # write answers 503 (see app/authentik_client.configured()). The
+            # authentik NetworkPolicy already allows hhccia-v2 -> authentik-server:9000.
+            - name: AUTHENTIK_API_URL
+              value: "http://authentik-server.authentik.svc.cluster.local"
+            - name: AUTHENTIK_API_TOKEN
+              valueFrom:
+                secretKeyRef: { name: hhccia-core-secrets, key: AUTHENTIK_API_TOKEN, optional: true }
+            # SER codes a user may self-assign (case-sensitive; "IN" != "in"). Keep
+            # in sync with the adapter SERVICES_IN_SCOPE + the signup radio choices.
+            - name: PROFILE_ALLOWED_SERVICES
+              value: "TI,IN,in"
           # Readiness verifies the dependencies (Postgres SELECT 1 + NATS
           # connected): a pod that boots before them, or loses them, is pulled
           # from the Service instead of answering 500s.


### PR DESCRIPTION
Wira las env vars del endpoint `PATCH /me/profile` del core (hhccia-core#27):

- `AUTHENTIK_API_URL` → authentik-server in-cluster.
- `AUTHENTIK_API_TOKEN` vía `secretKeyRef … optional: true` → el pod arranca aunque el token no esté sellado; hasta entonces el endpoint es read-only (503 al escribir).
- `PROFILE_ALLOWED_SERVICES=TI,IN,in` (case-sensitive; extensible).

## ⚠️ Orden de merge/deploy
Mergear **junto con**:
1. el bump del SHA de la imagen `hhccia-core` (con el código de perfil, hhccia-core#27 mergeado a main + build), y
2. el sellado del token en `hhccia-core-secrets` (`AUTHENTIK_API_TOKEN`) — runbook `Reference/Authentik API token para hhccia-core (self-service perfil).md`.

La NetworkPolicy de authentik ya permite hhccia-v2 → authentik-server:9000.