### PR TITLE
feat(cloudflared): raw-TCP tunnel to on-prem MSSQL (mssql-srn)

### DIFF
--- a/apps/operators/cloudflared-mssql/app.yaml
+++ b/apps/operators/cloudflared-mssql/app.yaml
@@ -1,0 +1,32 @@
+# cloudflared-mssql — a dedicated Cloudflare Tunnel connector that forwards a
+# raw TCP stream (MSSQL / TDS on 1433) from a public hostname to an MSSQL server
+# at a LAN IP outside the cluster. Separate from the strrl HTTP tunnel-ingress
+# controller (apps/operators/cloudflared): that one only handles HTTP Ingress.
+#
+# Raw manifests live in src/cloudflared-mssql (Deployment, ConfigMap, and the
+# SealedSecret holding the tunnel credentials). Deploys into the shared
+# `cloudflared` namespace, already allowed by the `operators` AppProject.
+#
+# One-time out-of-band setup (create tunnel, route DNS, seal creds, add a
+# Cloudflare Access policy) is documented in src/cloudflared-mssql/README.md.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloudflared-mssql
+  namespace: argocd
+spec:
+  project: operators
+  source:
+    repoURL: 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
+    targetRevision: master
+    path: src/cloudflared-mssql
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cloudflared
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/src/cloudflared-mssql/README.md
+++ b/src/cloudflared-mssql/README.md
@@ -1,0 +1,139 @@
+# cloudflared-mssql
+
+A dedicated **Cloudflare Tunnel** connector that exposes an on-prem **MSSQL**
+server (TDS over TCP 1433) — living at a LAN IP *outside* the cluster — behind a
+Cloudflare hostname, **without opening any inbound port** on the router.
+
+## Why this is separate from `apps/operators/cloudflared`
+
+That app is the strrl **`cloudflare-tunnel-ingress-controller`**: it turns
+Kubernetes **Ingress** objects into public hostnames over a tunnel it manages.
+It only speaks **HTTP/HTTPS/WebSocket**. MSSQL speaks **TDS over raw TCP**, which
+the HTTP tunnel (and Cloudflare's orange-cloud proxy) cannot carry. So we run a
+second, plain `cloudflared` with its **own** tunnel and a locally-managed
+`config.yaml` that declares a raw-TCP ingress rule. The two tunnels are fully
+independent.
+
+## Traffic path
+
+```
+SSMS / sqlcmd  ──►  cloudflared access tcp (your laptop, localhost:1433)
+                        │  authenticated to Cloudflare Access
+                        ▼
+                  Cloudflare edge  ──► tunnel ──►  cloudflared-mssql pod (cluster)
+                                                        │  tcp://<MSSQL_LAN_IP>:1433
+                                                        ▼
+                                                  MSSQL server (LAN)
+```
+
+Because the client side needs `cloudflared` (or WARP), the database is **never**
+directly reachable from the internet, and access is gated by a Cloudflare Access
+policy scoped to your identity.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `configmap.yaml` | `config.yaml` — the tunnel UUID + the `tcp://<MSSQL_LAN_IP>:1433` ingress rule |
+| `deployment.yaml` | 2× hardened `cloudflared` connectors (outbound-only) |
+| `credentials-sealedsecret.yaml` | tunnel `credentials.json`, sealed (⚠️ placeholder until you generate it) |
+| `../../apps/operators/cloudflared-mssql/app.yaml` | the Argo CD Application |
+
+---
+
+## One-time setup
+
+You need the `cloudflared` CLI logged in to the same Cloudflare account
+(`cloudflared tunnel login`), and `kubeseal` matching the controller
+(`0.37.0`, see `apps/operators/sealed-secrets/README.md`).
+
+### 1. Create the tunnel
+
+```bash
+cloudflared tunnel create mssql-tcp
+# → prints the tunnel UUID and writes ~/.cloudflared/<UUID>.json (credentials.json)
+```
+
+### 2. Route the DNS record to the tunnel
+
+```bash
+cloudflared tunnel route dns mssql-tcp mssql-srn.irupeconsultores.com
+# creates the proxied CNAME <UUID>.cfargotunnel.com in Cloudflare DNS
+```
+
+### 3. Fill in the two placeholders
+
+- `configmap.yaml` → set `tunnel: <TUNNEL_UUID>` and
+  `service: tcp://<MSSQL_LAN_IP>:1433` (the LAN IP:port of the MSSQL box; use
+  `1433` unless it listens elsewhere).
+
+### 4. Seal the credentials
+
+```bash
+kubectl create secret generic cloudflared-mssql-creds \
+  --namespace cloudflared \
+  --from-file=credentials.json=$HOME/.cloudflared/<UUID>.json \
+  --dry-run=client -o yaml \
+| kubeseal --controller-name sealed-secrets-controller \
+           --controller-namespace kube-system -o yaml \
+> src/cloudflared-mssql/credentials-sealedsecret.yaml
+```
+
+### 5. Gate it with Cloudflare Access (Zero Trust) — do NOT skip
+
+In the Zero Trust dashboard → **Access → Applications → Add → Self-hosted**:
+
+- **Application domain:** `mssql-srn.irupeconsultores.com`
+- **Policy:** Allow → *Emails* → `carlos.barroso@goconvey.com` (add others as
+  needed). Optionally require WARP / device posture.
+
+Without a policy, anyone who runs `cloudflared access tcp` against the hostname
+could reach the login prompt. With it, only your identity establishes the tunnel
+session.
+
+### 6. Commit & let Argo sync
+
+```bash
+git add src/cloudflared-mssql apps/operators/cloudflared-mssql
+git commit
+git push
+```
+
+The root app-of-apps discovers `apps/operators/cloudflared-mssql/app.yaml`, and
+the connectors register with the edge. Check:
+
+```bash
+kubectl -n cloudflared get pods -l app=cloudflared-mssql
+kubectl -n cloudflared logs -l app=cloudflared-mssql | grep -i "registered\|connection"
+```
+
+---
+
+## Connecting from your machine
+
+```bash
+# Terminal 1 — open the local proxy (prompts for Access login on first run):
+cloudflared access tcp --hostname mssql-srn.irupeconsultores.com --url localhost:1433
+```
+
+Then point your client at `localhost:1433`:
+
+- **SSMS / Azure Data Studio:** Server `localhost,1433`, enable
+  *Encrypt* + *Trust server certificate*.
+- **sqlcmd:** `sqlcmd -S localhost,1433 -U <user> -C`
+
+To skip the interactive terminal, install the **WARP** client and use Cloudflare
+Access *service tokens* / device enrollment instead — same tunnel, no per-session
+command.
+
+## Notes
+
+- **No router port is opened** — the connectors dial *out* to the Cloudflare edge
+  (443/7844).
+- Egress in the `cloudflared` namespace is unrestricted (same as the other
+  namespaces), so the pod reaches both the edge and the MSSQL LAN IP; no
+  NetworkPolicy change is required.
+- The image tag is pinned and Renovate bumps it; `no-autoupdate` keeps cloudflared
+  from self-updating out from under the pin.
+- Rotating the tunnel: recreate it, re-run steps 1–4, commit. Delete the old
+  tunnel (`cloudflared tunnel delete mssql-tcp`) once the new connectors are up.

--- a/src/cloudflared-mssql/configmap.yaml
+++ b/src/cloudflared-mssql/configmap.yaml
@@ -1,0 +1,34 @@
+# Locally-managed tunnel config for the raw-TCP MSSQL route. Unlike the strrl
+# cloudflare-tunnel-ingress-controller (apps/operators/cloudflared), which only
+# maps HTTP Ingress objects to public hostnames, this is a plain `cloudflared`
+# running its OWN dedicated tunnel that forwards a raw TCP stream to an MSSQL
+# server living at a LAN IP OUTSIDE the cluster.
+#
+# TDS (MSSQL) is not HTTP, so it cannot ride the HTTP tunnel/orange-cloud proxy.
+# The client side pairs with this via:
+#   cloudflared access tcp --hostname mssql-srn.irupeconsultores.com --url localhost:1433
+# then points SSMS/sqlcmd at localhost:1433.
+#
+# The MSSQL server lives at 192.168.5.132:1433 on the LAN; the node routes to it
+# directly (no in-cluster Service). See README.md for the tunnel/DNS/Access setup.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloudflared-mssql-config
+  namespace: cloudflared
+data:
+  config.yaml: |
+    tunnel: 98b16c57-a8ad-4540-ba20-f71268ea1242
+    credentials-file: /etc/cloudflared/creds/credentials.json
+    # Metrics + /ready health endpoint (scraped by the liveness probe).
+    metrics: 0.0.0.0:2000
+    # The image is pinned; cloudflared must not self-update.
+    no-autoupdate: true
+    # Keep at least this many connections to the Cloudflare edge for HA.
+    ingress:
+      # The MSSQL server is at a LAN IP the cluster node can route to. cloudflared
+      # dials it directly (no in-cluster Service needed) and streams raw TCP.
+      - hostname: mssql-srn.irupeconsultores.com
+        service: tcp://192.168.5.132:1433
+      # Everything else is refused.
+      - service: http_status:404

--- a/src/cloudflared-mssql/credentials-sealedsecret.yaml
+++ b/src/cloudflared-mssql/credentials-sealedsecret.yaml
@@ -1,0 +1,13 @@
+﻿---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cloudflared-mssql-creds
+  namespace: cloudflared
+spec:
+  encryptedData:
+    credentials.json: AgAXTD4VyMb/i37d2cWWXmSTXIeYKt3Fgjdprnv/6nM1cn9HFNOIRS8Kh9O8G32KA7v/Wf5C2EdDBQkCluXPA9hEr4RIqRmb7wb5k7m7dqS9nB14aWGrtfmCJ7oBMJCys6kdkJQN+Cd8s+uHoNS8WYuK8SF+uyp53A6cuQi8l3wCX03OXp3fboGT3E8qXfhK5XlhkD6fAmY8n8nJJr81q9cADc+d75CptOcI8Ldi2ag0MUwO0QsJz5qvD/K8ucQc/1TMo1fhuQI7oTXjnq/PyEd5vHKYTXULYUTwrjm5K/lPV51/1yQ5HnnQ586oNb2G0dSyVh7VJ60g1aT2deaFyVyqlUouYcT8y2BbZfEPLRSQEZAdqOx8J4skUpxLGioAFxEpIdLKgXvoiKmX62ztkGavIgrudiEAQ9+1RceMYqhNn8qiaByii9Av/xlut/UTPhDWTtT4B1QlQHALSqZeqFZUMuiXJaiU7+QnAST9QJs8858DzGSBUF2T+yuVoFFNsHfBvpTI5o3D+rbhnL/a9zhMGvOccwpXtfJ9yeVCxTV0HlnayIFy87nldCYyUDbXTbTJYCo8CRbC3BbMHDiLkh901hN3gOWQSK/E3pjWCQMKcZkVoWXjcpirZHokHC3olWMD+3xQhxsQTPR4JF9FZqfUl6EdNcIGIs5iNgea4lVg+owYawhMyORT8vtXXOkbzLv5MGYqxpPeUmZMZBINsuM4WP/MrgShgndDvHJ8LvC2aKsNgcYlF4iRv9nIxe0+LKj+F5mhkCoNM8aoxBbicJHruubOI9GghzCHlTeUa7sL4NEIhavZrfZob2PheYM/4bMy4l3blL9NlpFiusqu4rm24vB4JarGC5iEUuh7Iz0MSjJFSQ66BlX6pzsIGI+8NvZ4M0A/PcLlZu7LWRQ5+Fvez7ZctdaEO0dh5O6Zg1hN
+  template:
+    metadata:
+      name: cloudflared-mssql-creds
+      namespace: cloudflared

--- a/src/cloudflared-mssql/deployment.yaml
+++ b/src/cloudflared-mssql/deployment.yaml
@@ -1,0 +1,91 @@
+# Plain `cloudflared` connector for the MSSQL raw-TCP tunnel. Runs a dedicated
+# tunnel (config in cloudflared-mssql-config, creds in the SealedSecret
+# cloudflared-mssql-creds). Independent of the strrl ingress-controller pod that
+# shares this namespace — it does NOT touch that tunnel or its HTTP hostnames.
+#
+# Outbound-only: cloudflared opens connections TO the Cloudflare edge (443/7844),
+# so no inbound router port is exposed. Reachability to the MSSQL LAN IP is over
+# the node's normal L3 routing (egress is unrestricted here, same as the other
+# namespaces — see src/planka/networkpolicies.yaml).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared-mssql
+  namespace: cloudflared
+  labels:
+    app: cloudflared-mssql
+spec:
+  replicas: 2          # two connectors => zero-downtime restarts / edge HA
+  selector:
+    matchLabels:
+      app: cloudflared-mssql
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: cloudflared-mssql
+        logs.cjbarroso.com/collect: "true"   # opt in to log aggregation
+    spec:
+      automountServiceAccountToken: false
+      # Spread the two connectors across restarts; single-node k3s tolerates this.
+      containers:
+        - name: cloudflared
+          # Pinned tag; Renovate bumps it to the latest release + digest. cloudflared
+          # refuses to self-update (no-autoupdate in config.yaml). Keep the
+          # connector within ~1 minor of the CLI that creates/rotates the tunnel.
+          image: cloudflare/cloudflared:2026.6.1
+          args:
+            - tunnel
+            - --config
+            - /etc/cloudflared/config.yaml
+            - run
+          ports:
+            - name: metrics
+              containerPort: 2000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cloudflared
+              readOnly: true
+            - name: creds
+              mountPath: /etc/cloudflared/creds
+              readOnly: true
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: config
+          configMap:
+            name: cloudflared-mssql-config
+        - name: creds
+          secret:
+            secretName: cloudflared-mssql-creds


### PR DESCRIPTION
## What

Exposes the on-prem **MSSQL** server (`192.168.5.132:1433`, TDS/raw TCP) behind `mssql-srn.irupeconsultores.com` via a **dedicated Cloudflare Tunnel** (`98b16c57-…`), run by a plain `cloudflared` connector.

## Why a second, separate tunnel

The existing `apps/operators/cloudflared` is the strrl **HTTP** tunnel-ingress-controller — it only carries HTTP/S/WebSocket and manages its tunnel from Ingress objects. MSSQL is raw TCP, so it needs a locally-managed `config.yaml` with a `tcp://` ingress rule on its own tunnel. The two are fully independent.

## Security posture

- **No inbound router port opened** — the connectors dial out to the Cloudflare edge.
- Access gated by a **Cloudflare Access** self-hosted policy on the hostname (already configured).
- Client pairs via `cloudflared access tcp --hostname mssql-srn.irupeconsultores.com --url localhost:1433`.
- Connector runs hardened: non-root, read-only rootfs, all caps dropped, RuntimeDefault seccomp.

## Contents

- `src/cloudflared-mssql/` — Deployment (2× for edge HA), ConfigMap, sealed tunnel credentials, README with full setup/connect docs
- `apps/operators/cloudflared-mssql/app.yaml` — Argo Application (`operators` project → `cloudflared` namespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)