### PR TITLE
docs: point access-client runbook at the cloudflared-access component

### DIFF
--- a/docs/09-CLOUDFLARE-ACCESS-CLIENT-SERVICES.md
+++ b/docs/09-CLOUDFLARE-ACCESS-CLIENT-SERVICES.md
@@ -1,15 +1,21 @@
 # Cloudflare Access Client Proxies as Windows Services
 
 The MSSQL and Kubernetes-API tunnels are reached from a workstation via
-`cloudflared access tcp` proxies that bind `localhost:1433` / `localhost:6443`.
-This runbook makes those two proxies **persistent Windows services** (auto-start
-at boot, restart on crash) using **WinSW**, authenticated non-interactively with a
+`cloudflared access tcp` proxies that bind `localhost:1433` / `localhost:16443`.
+Those two proxies run as **persistent Windows services** (auto-start at boot,
+restart on crash) using **WinSW**, authenticated non-interactively with a
 **Cloudflare Access service token**.
 
 > The server-side tunnel connectors already run 24/7 in the cluster (Argo apps
-> `cloudflared-mssql`, `cloudflared-k8s-api`). This runbook is only about the
-> **client** proxies. Related: `docs/08-MSSQL-TUNNEL-RUNBOOK.md`,
-> `src/cloudflared-k8s-api/README.md`.
+> `cloudflared-mssql`, `cloudflared-k8s-api`). This runbook covers only the
+> **Cloudflare-side** setup (service token + Access policy). Related:
+> `docs/08-MSSQL-TUNNEL-RUNBOOK.md`, `src/cloudflared-k8s-api/README.md`.
+
+> **The client install lives in code.** The Windows service installer/uninstaller,
+> its config template, and full client docs are a version-controlled component in
+> the personal `computer` repo: **`cloudflared-access/`** (README + `install.ps1` +
+> `uninstall.ps1` + `config.example.json`). This runbook no longer carries the
+> loose `C:\ProgramData\cloudflared-access\` files — use that component instead.
 
 ## Why a service token (the critical detail)
 
@@ -24,16 +30,17 @@ Secret) authenticates headlessly and doesn't expire that way.
   own auth (SQL login / kubectl mTLS). The token alone reaches only the login
   prompt.
 - The token secret lives in the service XML on disk → the installer restricts the
-  directory ACL to `SYSTEM` + `Administrators`, and the token is passed via env
-  vars so it never shows on the process command line.
+  install-dir ACL to `SYSTEM` + `Administrators`, and the token is passed via env
+  vars so it never shows on the process command line. The secret never enters git
+  (it lives only in the component's gitignored `config.json`).
 - These services keep a **standing path to the DB and the k8s control plane** on
-  this box. If it's a roaming laptop, consider installing only the MSSQL service
-  and keeping the k8s API on-demand. **Revoke the service token** immediately if
-  the machine is lost — that instantly kills both proxies' Access auth.
+  this box. If it's a roaming laptop, install only the MSSQL proxy and keep the
+  k8s API on-demand. **Revoke the service token** immediately if the machine is
+  lost — that instantly kills both proxies' Access auth.
 
 ---
 
-## Setup
+## Cloudflare-side setup
 
 ### 1. Create the Access service token
 
@@ -48,89 +55,28 @@ Access → Applications → the app → **Policies** → add a policy with
 Action = **Service Auth**, Include → **Service Token** → the token you created.
 (Keep your existing identity/email policy for interactive use.)
 
-### 3. Files (staged at `C:\ProgramData\cloudflared-access\`)
-
-| File | Purpose |
-|---|---|
-| `cloudflared.exe` | stable copy of the binary (per-user WinGet path isn't reachable by a LocalSystem service) |
-| `cloudflared-access-mssql.xml` | WinSW def → `mssql-srn` → `localhost:1433` |
-| `cloudflared-access-k8s.xml` | WinSW def → `kubernetes-srn` → `localhost:6443` |
-| `install-services.ps1` | elevated installer (downloads WinSW, installs + starts both, locks ACL) |
-
-WinSW service definition (MSSQL shown; the k8s one is identical with `6443` and
-the `kubernetes-srn` hostname):
-
-```xml
-<service>
-  <id>cloudflared-access-mssql</id>
-  <name>Cloudflared Access - MSSQL (mssql-srn)</name>
-  <executable>%BASE%\cloudflared.exe</executable>
-  <arguments>access tcp --hostname mssql-srn.irupeconsultores.com --url localhost:1433 --loglevel info</arguments>
-  <env name="TUNNEL_SERVICE_TOKEN_ID" value="__FILL_SERVICE_TOKEN_ID__"/>
-  <env name="TUNNEL_SERVICE_TOKEN_SECRET" value="__FILL_SERVICE_TOKEN_SECRET__"/>
-  <startmode>Automatic</startmode>
-  <onfailure action="restart" delay="10 sec"/>
-  <resetfailure>1 hour</resetfailure>
-  <log mode="roll-by-size"><sizeThreshold>10240</sizeThreshold><keepFiles>3</keepFiles></log>
-</service>
-```
-
-### 4. Fill in the token + install
-
-1. Edit both `.xml` files, replacing `__FILL_SERVICE_TOKEN_ID__` and
-   `__FILL_SERVICE_TOKEN_SECRET__` with the token values from step 1.
-2. In an **elevated** PowerShell:
-
-   ```powershell
-   & C:\ProgramData\cloudflared-access\install-services.ps1
-   ```
-
-   It refuses to proceed if the placeholders are still present, downloads WinSW
-   `v2.12.0`, installs + starts both services, and locks the directory ACL.
-
 ---
 
-## Verify
+## Client install & verify
+
+See the **`cloudflared-access/`** component in the `computer` repo. In short: copy
+`config.example.json` → `config.json`, paste in the token, then run `install.ps1`
+from an elevated PowerShell. Verify with:
 
 ```powershell
 Get-Service cloudflared-access-mssql, cloudflared-access-k8s
-Test-NetConnection localhost -Port 1433   # TcpTestSucceeded : True
-Test-NetConnection localhost -Port 6443   # TcpTestSucceeded : True
+Test-NetConnection localhost -Port 1433    # TcpTestSucceeded : True
+Test-NetConnection localhost -Port 16443   # TcpTestSucceeded : True
 ```
 
-Then use them exactly as before — the proxies are always listening:
+Then use them as usual — the proxies are always listening:
 
 ```powershell
 sqlcmd -S "localhost,1433" -U <user> -C -Q "SELECT @@VERSION"
-# kubectl via a kubeconfig whose server is https://127.0.0.1:6443
-```
-
-## Logs & operations
-
-```powershell
-Get-Content C:\ProgramData\cloudflared-access\cloudflared-access-k8s.out.log -Tail 30
-Restart-Service cloudflared-access-mssql
+# kubectl --context nexoflow-cf  (cluster server https://127.0.0.1:16443)
 ```
 
 ## Rotate the service token
 
-Create a new token, update both apps' policies, edit the two `.xml` files, then
-`Restart-Service` both. Delete the old token in the dashboard.
-
-## Uninstall
-
-```powershell
-foreach ($s in 'cloudflared-access-mssql','cloudflared-access-k8s') {
-  & "C:\ProgramData\cloudflared-access\$s.exe" stop
-  & "C:\ProgramData\cloudflared-access\$s.exe" uninstall
-}
-```
-
-## Notes
-
-- WinSW needs one exe per service, named to match its XML — the installer copies
-  `WinSW-x64.exe` to `cloudflared-access-mssql.exe` / `cloudflared-access-k8s.exe`.
-- Services run as `LocalSystem` by default; service-token auth needs no user
-  profile / `cert.pem`, so LocalSystem is fine.
-- After a `cloudflared` upgrade, re-copy the new `cloudflared.exe` into the folder
-  and `Restart-Service` both.
+Create a new token, update both apps' policies, edit the component's `config.json`,
+re-run `install.ps1`, then delete the old token in the dashboard.


### PR DESCRIPTION
## What

Trims `docs/09-CLOUDFLARE-ACCESS-CLIENT-SERVICES.md` to the **Cloudflare-side** setup (service token + Service Auth policy) and points the client install at the new version-controlled **`cloudflared-access/`** component in the personal `computer` repo, instead of carrying loose `C:\ProgramData\cloudflared-access\` files.

Also corrects the k8s client proxy port to **16443** (matches the existing `nexoflow-cf` kubeconfig context).

## Why

The Windows service installer/uninstaller, config template, and troubleshooting now live as a proper component (README + `install.ps1` + `uninstall.ps1` + `diagnose-access.ps1` + `config.example.json`), so the runbook shouldn't duplicate the client mechanics.

## Verified

End-to-end: `kubectl --context nexoflow-cf get nodes` returns the node through the tunnel; `curl` to `localhost:16443` gets a `401` from the apiserver (service-token auth passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)