### PR TITLE
staging(hhccia-front): set APP_ENV=staging for the visual indicator

### DIFF
--- a/src/hhccia-staging/hhccia-front.yaml
+++ b/src/hhccia-staging/hhccia-front.yaml
@@ -44,6 +44,10 @@ spec:
               value: "https://auth.irupeconsultores.com/application/o/hhccia-staging/"
             - name: AUTHENTIK_CLIENT_ID
               value: "hhccia-front-staging"
+            # Drives the staging visual indicators (amber ribbon, tinted chrome,
+            # [STG] tab marker). Prod (hhccia-v2) leaves this unset → clean UI.
+            - name: APP_ENV
+              value: "staging"
           readinessProbe:
             httpGet: { path: /, port: 8080 }
             initialDelaySeconds: 3


### PR DESCRIPTION
## What & why

Companion to hhccia-front PR #31 (staging visual indicator). Sets `APP_ENV: "staging"` on the staging front Deployment so the amber ribbon + tinted chrome + `[STG]` tab marker light up on `medaudit-staging.irupeconsultores.com`.

Prod (`src/hhccia-v2/hhccia-front.yaml`) intentionally leaves `APP_ENV` unset → its UI is unchanged.

## Note on ordering

The front CI (`update-gitops-staging`) only `sed`-rewrites the `image:` line of `src/hhccia-staging/hhccia-front.yaml`, so this `APP_ENV` env var persists across staging auto-rollouts. **Merge this before/with the front PR** so the banner appears on the first roll that carries the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)