### PR TITLE
Deploy shared Cognee and back up Hermes2 state

### DIFF
--- a/apps/hermes2/app.yaml
+++ b/apps/hermes2/app.yaml
@@ -11,6 +11,7 @@ spec:
     targetRevision: master
     directory:
       recurse: false
+      exclude: '*.example.yaml'
   destination:
     server: https://kubernetes.default.svc
     namespace: hermes2

--- a/apps/velero/values.yaml
+++ b/apps/velero/values.yaml
@@ -60,12 +60,15 @@ credentials:
 # CNPG data volumes are excluded from FS backup via pod annotation (set in
 # src/authentik/postgres-cnpg.yaml). Vaultwarden gets a consistent
 # `sqlite3 .backup` from its own CronJob (src/vaultwarden/) before this runs.
+# hermes2 contains the operational agent state and shared Cognee knowledge PVC;
+# both are included in the same daily filesystem backup and 30-day retention.
 schedules:
   stateful-daily:
     schedule: "0 2 * * *"          # 02:00 daily
     template:
       includedNamespaces:
         - authentik
+        - hermes2
         - vaultwarden
       defaultVolumesToFsBackup: true
       ttl: 720h                     # 30 days

--- a/apps/velero/values.yaml
+++ b/apps/velero/values.yaml
@@ -46,9 +46,10 @@ credentials:
 
 # Daily file-system backup of the cluster's stateful namespaces → R2 (bucket
 # `velero-backups`), 30-day retention. Covers the irreproducible state that is
-# NOT in Git: Authentik Postgres (SSO/OIDC config) and Vaultwarden (password
-# vault). Everything else is redeployable from Git, so it's intentionally out of
-# scope (see `Reference/Disaster Preparedness - full backup coverage plan.md`).
+# NOT in Git: Authentik Postgres (SSO/OIDC config), Hermes2 agent/Cognee state,
+# and Vaultwarden (password vault). Other namespaces remain redeployable from
+# Git and intentionally out of scope (see
+# `Reference/Disaster Preparedness - full backup coverage plan.md`).
 #
 # NOTE: `default` (Gitea) was dropped 2026-05-31 — Gitea is decommissioned (no
 # running pods; only orphaned PVCs remain), so there's no live volume data to

--- a/src/hermes2/cognee-openai-sealedsecret.yaml
+++ b/src/hermes2/cognee-openai-sealedsecret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: hermes2-cognee-openai
+  namespace: hermes2
+spec:
+  encryptedData:
+    LLM_API_KEY: AgCsWjri3drBvYzyw+IJHEwmmMFgEa9eHonDJMUMPx9x7mh2ys5luF+Z1sBC56DJ8/s5Zoax2WwUFJjrWw+pen+X0+hBOZarWCXPFtw9dTyXZRd0kMGuJiCQ3L5k8oTEfAjrIhYJGKtXokjnS0O/pivJV5YJz+e6qqYnyrJP056YlJbJ6LpPFQJO9BlaWPBBx2x1znAsAXTgXP8NYRimL5MELABnnWs81vBmzohABG5EQXyTxkanZVqfI83aKn+XvRT+dUzW0RRILyWMlRev2dm9h7kPImucGnwHuRciZhb//MNIfnBn6YnYsCrKxtJj1t1gb4T30OCACwoADMU+3iilIH1+fGoEMmUOdv8eeQefl5Jb6gZkVuQwGir1DqFNSy+KL8/ZoLDIof4byKeqNW8h2V8kxXRJL5UB21wPWIVuC7nE30R9Ogq423W0K12t48CX/w1uspPRqbz5uHTAQ+gXq2TIUNfcMr5HjzaN5LRZGXz+JVyGZcJWnDZBOHk8/ukYPVmosZ1Cx+ejobEL3KInhNuZqpjkpxIlA+Zgy1brn4kfEQ1/eeNEm6ku+bl9fMwDLK9xfHwCkOYkGCmqGBLJKO8cSN9pqzdKcVR9RRnvoxUu3FVJEvKy92VA9lZeCa2MLSfzK4epaEgnsWPc7YxWEQjsx670/bGb+m/zcGjnCfAE5McdU2xWHdksLRpca3Oyqr2cTHXL+cZORcMlOaQFB9y/cl5Xh1RaQ4tnBAfHUt/rL0o95AvpVagj0182lcHHOigRhMMNqYvfhoTMqR50p8RUtFSJddkiO00c1Lan6rUDBcCnvHTz2nKY9GYrsyfuQivQ+aRNwi14kypHtoh42/X8FksAPoKq0MOaqfqWKd/5KP4ZNk7mbshQGIYvCwKYSMKKnBxRVZz58EtGIgGqI6jzgg==
+  template:
+    metadata:
+      name: hermes2-cognee-openai
+      namespace: hermes2
+    type: Opaque

--- a/src/hermes2/cognee-openai-sealedsecret.yaml.example
+++ b/src/hermes2/cognee-openai-sealedsecret.yaml.example
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes2-cognee-openai
+  namespace: hermes2
+type: Opaque
+stringData:
+  LLM_API_KEY: "REPLACE_ME"

--- a/src/hermes2/cognee-shared.yaml
+++ b/src/hermes2/cognee-shared.yaml
@@ -1,0 +1,186 @@
+# Central Cognee backend shared by Gretchen and Incident Response Engineer.
+# The OpenAI key is materialized by the companion SealedSecret; plaintext must
+# never be committed.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cognee-data
+  namespace: hermes2
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cognee-backend
+  namespace: hermes2
+  labels:
+    app: cognee-backend
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: cognee-backend
+  template:
+    metadata:
+      labels:
+        app: cognee-backend
+        logs.cjbarroso.com/collect: "true"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cognee
+          image: cognee/cognee:main@sha256:77dca10caac45f46100abf9c9e539ba38bf7271da23586f6f682af31a945c714
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes2-cognee-openai
+                  key: LLM_API_KEY
+            - name: TELEMETRY_DISABLED
+              value: "true"
+            - name: REQUIRE_AUTHENTICATION
+              value: "false"
+          ports:
+            - name: http
+              containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: cognee-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cognee-backend
+  namespace: hermes2
+spec:
+  selector:
+    app: cognee-backend
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cognee-mcp
+  namespace: hermes2
+  labels:
+    app: cognee-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cognee-mcp
+  template:
+    metadata:
+      labels:
+        app: cognee-mcp
+        logs.cjbarroso.com/collect: "true"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cognee-mcp
+          image: cognee/cognee-mcp:main@sha256:e3bbe07a7297c64fda9d5ce78c9cb73a3dc4ad9b790d07d3e39cb7dc6004d189
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: TRANSPORT_MODE
+              value: http
+            - name: API_URL
+              value: http://cognee-backend:8000
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes2-cognee-openai
+                  key: LLM_API_KEY
+          ports:
+            - name: http
+              containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 90
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cognee-mcp
+  namespace: hermes2
+spec:
+  selector:
+    app: cognee-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/src/hermes2/cognee-shared.yaml
+++ b/src/hermes2/cognee-shared.yaml
@@ -134,11 +134,6 @@ spec:
               value: http
             - name: API_URL
               value: http://cognee-backend:8000
-            - name: LLM_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hermes2-cognee-openai
-                  key: LLM_API_KEY
           ports:
             - name: http
               containerPort: 8000
@@ -180,6 +175,159 @@ metadata:
 spec:
   selector:
     app: cognee-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+---
+# Incident Response receives a server-enforced read-only MCP surface.  The
+# full Cognee MCP contains mutating tools (remember, cognify, forget), so a
+# client-side tool allow-list would not be an adequate security boundary.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cognee-readonly-mcp
+  namespace: hermes2
+data:
+  server.py: |
+    import asyncio
+    import os
+
+    import httpx
+    import uvicorn
+    from mcp.server import FastMCP
+    from starlette.responses import JSONResponse
+
+    BACKEND_URL = os.environ.get("API_URL", "http://cognee-backend:8000")
+    mcp = FastMCP("Cognee Read Only")
+
+
+    @mcp.tool()
+    async def recall(
+        query: str,
+        search_type: str | None = None,
+        datasets: str | None = None,
+        session_id: str | None = None,
+        system_prompt: str | None = None,
+        top_k: int = 15,
+    ) -> object:
+        """Search shared project knowledge without changing it."""
+        payload = {"query": query, "top_k": max(1, min(top_k, 100))}
+        if search_type:
+            payload["search_type"] = search_type.upper()
+        if datasets:
+            payload["datasets"] = [
+                item.strip() for item in datasets.split(",") if item.strip()
+            ]
+        if session_id:
+            payload["session_id"] = session_id
+        if system_prompt:
+            payload["system_prompt"] = system_prompt
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.post(
+                f"{BACKEND_URL}/api/v1/recall", json=payload
+            )
+            response.raise_for_status()
+            return response.json()
+
+
+    @mcp.custom_route("/health", methods=["GET"])
+    async def health_check(request):
+        return JSONResponse({"status": "ok"})
+
+
+    async def main():
+        mcp.settings.host = "0.0.0.0"
+        mcp.settings.port = 8000
+        app = mcp.streamable_http_app()
+        server = uvicorn.Server(
+            uvicorn.Config(app, host="0.0.0.0", port=8000, log_level="info")
+        )
+        await server.serve()
+
+
+    if __name__ == "__main__":
+        asyncio.run(main())
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cognee-readonly-mcp
+  namespace: hermes2
+  labels:
+    app: cognee-readonly-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cognee-readonly-mcp
+  template:
+    metadata:
+      labels:
+        app: cognee-readonly-mcp
+        logs.cjbarroso.com/collect: "true"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cognee-readonly-mcp
+          image: cognee/cognee-mcp:main@sha256:e3bbe07a7297c64fda9d5ce78c9cb73a3dc4ad9b790d07d3e39cb7dc6004d189
+          imagePullPolicy: IfNotPresent
+          command: [python, /opt/readonly/server.py]
+          env:
+            - name: API_URL
+              value: http://cognee-backend:8000
+          ports:
+            - name: http
+              containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 90
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - name: server
+              mountPath: /opt/readonly
+              readOnly: true
+      volumes:
+        - name: server
+          configMap:
+            name: cognee-readonly-mcp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cognee-readonly-mcp
+  namespace: hermes2
+spec:
+  selector:
+    app: cognee-readonly-mcp
   ports:
     - name: http
       port: 8000

--- a/src/hermes2/networkpolicies.yaml
+++ b/src/hermes2/networkpolicies.yaml
@@ -36,7 +36,7 @@ spec:
     matchExpressions:
       - key: app
         operator: NotIn
-        values: [cognee-backend, cognee-mcp]
+        values: [cognee-backend, cognee-mcp, cognee-readonly-mcp]
   ingress:
     - from:
         - podSelector: {}
@@ -53,8 +53,10 @@ spec:
   ingress:
     - from:
         - podSelector:
-            matchLabels:
-              app: cognee-mcp
+            matchExpressions:
+              - key: app
+                operator: In
+                values: [cognee-mcp, cognee-readonly-mcp]
       ports:
         - protocol: TCP
           port: 8000
@@ -62,7 +64,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-cognee-mcp-from-authorized-hermes
+  name: allow-cognee-mcp-from-hermes
   namespace: hermes2
 spec:
   podSelector:
@@ -73,6 +75,21 @@ spec:
         - podSelector:
             matchLabels:
               app: hermes2
+      ports:
+        - protocol: TCP
+          port: 8000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cognee-readonly-mcp-from-incident-response
+  namespace: hermes2
+spec:
+  podSelector:
+    matchLabels:
+      app: cognee-readonly-mcp
+  ingress:
+    - from:
         - podSelector:
             matchLabels:
               app: hermes2-incident-response

--- a/src/hermes2/networkpolicies.yaml
+++ b/src/hermes2/networkpolicies.yaml
@@ -31,10 +31,54 @@ metadata:
   name: allow-intra-namespace
   namespace: hermes2
 spec:
-  podSelector: {}
+  # Cognee holds shared project context and has narrower policies below.
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: NotIn
+        values: [cognee-backend, cognee-mcp]
   ingress:
     - from:
         - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cognee-backend-from-mcp
+  namespace: hermes2
+spec:
+  podSelector:
+    matchLabels:
+      app: cognee-backend
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: cognee-mcp
+      ports:
+        - protocol: TCP
+          port: 8000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cognee-mcp-from-authorized-hermes
+  namespace: hermes2
+spec:
+  podSelector:
+    matchLabels:
+      app: cognee-mcp
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: hermes2
+        - podSelector:
+            matchLabels:
+              app: hermes2-incident-response
+      ports:
+        - protocol: TCP
+          port: 8000
 ---
 # Kubelet probes + `kubectl port-forward` reach the pod from the node. Without
 # this the dashboard/API port-forward (the only access path for this instance)


### PR DESCRIPTION
## Summary

- deploy a persistent Cognee backend shared by Hermes profiles
- expose full MCP to the main Hermes workload and a server-enforced read-only `recall` facade to Incident Response
- seal the existing OpenAI credential and keep plaintext out of Git
- isolate Cognee components with NetworkPolicies
- include the complete `hermes2` namespace (agent PVCs and Cognee state) in the daily Velero filesystem backup with 30-day retention

## Validation

- Kubernetes client and server-side dry-runs passed
- Velero 12.0.2 Helm render passed client dry-run
- YAML, whitespace, and hardcoded-secret pre-commit hooks passed
- exact pinned Cognee MCP image successfully imported all facade dependencies and built the Streamable HTTP app
- independent spec and standards reviews completed

## Safety

This PR intentionally excludes the separate, premature cluster-wide pod-mutation RBAC change. Incident Response remains read-only until the documented approval-gate drills are completed.