### PR TITLE
Fix Cognee MCP non-root runtime

### DIFF
--- a/src/hermes2/cognee-shared.yaml
+++ b/src/hermes2/cognee-shared.yaml
@@ -166,6 +166,8 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: false
             runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
 ---
 apiVersion: v1
 kind: Service
@@ -311,6 +313,8 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
           volumeMounts:
             - name: server
               mountPath: /opt/readonly


### PR DESCRIPTION
## Root cause

Kubernetes rejected both MCP containers because the pinned image declares the non-root user by name. With `runAsNonRoot: true`, kubelet cannot verify a non-numeric image user.

## Fix

Set the verified image UID/GID (`1000:1000`) explicitly on the full and read-only MCP containers.

## Validation

- exact pinned image reports `uid=1000(cognee) gid=1000(cognee)`
- Kubernetes server-side dry-run passed
- YAML, whitespace, and hardcoded-secret hooks passed