### PR TITLE
Move Cognee storage to persistent pgvector

### DIFF
--- a/src/hermes2/cognee-postgres-sealedsecret.yaml
+++ b/src/hermes2/cognee-postgres-sealedsecret.yaml
@@ -1,0 +1,12 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cognee-postgres
+  namespace: hermes2
+spec:
+  encryptedData:
+    POSTGRES_PASSWORD: AgA3is+dBoGhhElAfWYZ1AsTqbrV0KgrruyLWsF+rNcKG6CEuEPwl8DEJR/UCJQofo1fMhNUJ/Tuq3B0gmrrBP35XjvrsmdnkoantRR7uenNYHn/9aci8JemgVgX8p8hThAHHLYC1+ibcGfoLz92bpkPaJ7kF27fTka3XKg4187aI0vKmuvxaPaxcv4Psm2EDAwz+RycR13ocWJgNa2lW7Ugpum1/uHxOH2ilvHXUJLCy2kCT6WUWfmZB/PIDMKHLxfhi4KkrbxCtqzFlfJ+IT3oa9x1RPzZrhL3oztYrSDuVr1PG6z8OfkwH1V3fMmUF+D+pBA+rMSJoXjbshKsaftPcPqAB2diwnjQ4GlolhuYymxD8ssDMM89oWKP6GkvS1oQEU4XRKRVd33xC/RPdvkBadZRMVH0qhVPbKt+WHUVO/EogO1s01nVXRuDs9e0w+hps4JIoGxNS8Jiu2Yjmkm+EienWdTuYOugio4zwd6UsXtIpj6u8nUeGN2Z1Bl20N8wtBUMy0oW8gpMRUeVKTGsiijQwB8qLcjxSSAqfzSCc2/2FU21BvJmQAE4SxlVRmI8Viz3DaXcscedkh4qL89frQlxb7TPjkt2deDlYoXObQyB2GAG14H4JxLqSH4ajXz6jwH0PBN17kf/bkMF7U1nqQ9TgZReTgdXV1TV2TyqvSymVyKq/iE7K6GeMAnVXmd5IPLJPWPeki5pn/H2LByyO1hTlHSLf/ategeD9hyvp7uf2tJR37I7qGTD0w==
+  template:
+    metadata:
+      name: cognee-postgres
+      namespace: hermes2

--- a/src/hermes2/cognee-postgres-sealedsecret.yaml.example
+++ b/src/hermes2/cognee-postgres-sealedsecret.yaml.example
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cognee-postgres
+  namespace: hermes2
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: "REPLACE_ME"

--- a/src/hermes2/cognee-shared.yaml
+++ b/src/hermes2/cognee-shared.yaml
@@ -13,6 +13,112 @@ spec:
     requests:
       storage: 10Gi
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cognee-postgres-data
+  namespace: hermes2
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cognee-postgres
+  namespace: hermes2
+  labels:
+    app: cognee-postgres
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: cognee-postgres
+  template:
+    metadata:
+      labels:
+        app: cognee-postgres
+        logs.cjbarroso.com/collect: "true"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postgres
+          image: pgvector/pgvector:pg17@sha256:815bf5378222044da3b34d98e6a5fdac37b15c428b67d09c7c2d90a038e597bf
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: cognee
+            - name: POSTGRES_USER
+              value: cognee
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cognee-postgres
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgres
+              containerPort: 5432
+          startupProbe:
+            exec:
+              command: [pg_isready, -U, cognee, -d, cognee]
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command: [pg_isready, -U, cognee, -d, cognee]
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: [pg_isready, -U, cognee, -d, cognee]
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: cognee-postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cognee-postgres
+  namespace: hermes2
+spec:
+  selector:
+    app: cognee-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,6 +157,46 @@ spec:
               value: "true"
             - name: REQUIRE_AUTHENTICATION
               value: "false"
+            - name: ENABLE_BACKEND_ACCESS_CONTROL
+              value: "false"
+            - name: SYSTEM_ROOT_DIRECTORY
+              value: /app/data/system
+            - name: DATA_ROOT_DIRECTORY
+              value: /app/data/content
+            - name: VECTOR_DB_PROVIDER
+              value: pgvector
+            - name: VECTOR_DATASET_DATABASE_HANDLER
+              value: pgvector
+            - name: VECTOR_DB_HOST
+              value: cognee-postgres
+            - name: VECTOR_DB_PORT
+              value: "5432"
+            - name: VECTOR_DB_NAME
+              value: cognee
+            - name: VECTOR_DB_USERNAME
+              value: cognee
+            - name: VECTOR_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cognee-postgres
+                  key: POSTGRES_PASSWORD
+            - name: GRAPH_DATABASE_PROVIDER
+              value: postgres
+            - name: GRAPH_DATASET_DATABASE_HANDLER
+              value: postgres_graph
+            - name: GRAPH_DATABASE_HOST
+              value: cognee-postgres
+            - name: GRAPH_DATABASE_PORT
+              value: "5432"
+            - name: GRAPH_DATABASE_NAME
+              value: cognee
+            - name: GRAPH_DATABASE_USERNAME
+              value: cognee
+            - name: GRAPH_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cognee-postgres
+                  key: POSTGRES_PASSWORD
           ports:
             - name: http
               containerPort: 8000

--- a/src/hermes2/networkpolicies.yaml
+++ b/src/hermes2/networkpolicies.yaml
@@ -36,7 +36,11 @@ spec:
     matchExpressions:
       - key: app
         operator: NotIn
-        values: [cognee-backend, cognee-mcp, cognee-readonly-mcp]
+        values:
+          - cognee-backend
+          - cognee-mcp
+          - cognee-postgres
+          - cognee-readonly-mcp
   ingress:
     - from:
         - podSelector: {}
@@ -60,6 +64,24 @@ spec:
       ports:
         - protocol: TCP
           port: 8000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cognee-postgres-from-backend
+  namespace: hermes2
+spec:
+  podSelector:
+    matchLabels:
+      app: cognee-postgres
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: cognee-backend
+      ports:
+        - protocol: TCP
+          port: 5432
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Root cause

The pinned backend image's bundled LanceDB native module exits with SIGILL on the cluster node CPU. The initial Cognee system/data roots also pointed outside the mounted PVC.

## Fix

- deploy a pinned Postgres 17 + pgvector workload with its own PVC
- configure Cognee vector and graph providers to use Postgres
- point Cognee system/content roots at the existing persistent PVC
- disable backend access control consistently with the intentionally unauthenticated, NetworkPolicy-isolated API
- seal a generated database password; no plaintext credential enters Git
- permit Postgres ingress only from the Cognee backend

Both PVCs are in `hermes2`, which is included in the daily Velero filesystem backup.

## Validation

- isolated imports proved LanceDB is the SIGILL source; pgvector imports cleanly
- pinned pgvector digest and runtime UID verified
- Kubernetes server-side dry-run passed
- YAML, whitespace, and hardcoded-secret hooks passed