### PR TITLE
Roll out updated Cognee read-only facade

### DIFF
--- a/src/hermes2/cognee-shared.yaml
+++ b/src/hermes2/cognee-shared.yaml
@@ -423,6 +423,8 @@ spec:
       app: cognee-readonly-mcp
   template:
     metadata:
+      annotations:
+        config.cjbarroso.com/revision: "2"
       labels:
         app: cognee-readonly-mcp
         logs.cjbarroso.com/collect: "true"


### PR DESCRIPTION
Bump the read-only MCP pod template revision so Kubernetes recreates the pod with the already-merged ConfigMap hostname allowlist.

Server-side dry-run and all local pre-commit hooks passed.