### PR TITLE
Fix root app-of-apps OutOfSync: drop redundant directory.recurse

### DIFF
--- a/apps/calibre-web-automated/app.yaml
+++ b/apps/calibre-web-automated/app.yaml
@@ -17,8 +17,6 @@ spec:
     repoURL: 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
     path: src/calibre-web-automated
     targetRevision: master
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: calibre-web-automated

--- a/apps/pami/app.yaml
+++ b/apps/pami/app.yaml
@@ -9,8 +9,6 @@ spec:
     repoURL: 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
     path: src/pami
     targetRevision: master
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: pami


### PR DESCRIPTION
## Problem

The `root` app-of-apps reports `OutOfSync` (Healthy) because two child `Application` manifests perpetually diff:

- `apps/calibre-web-automated/app.yaml`
- `apps/pami/app.yaml`

Both set only `source.directory.recurse: false`, which is the default. Argo CD normalizes the entire `directory` block away in the live object, so the parent compares git (has the block) against the live `Application` (no `directory` field) and never converges.

`hermes2` / `hhccia-*` use the same `recurse: false` but also set a non-default `exclude`, which keeps the block present in the live object — so they stay Synced. These two set nothing but the default, so the block is safe to remove.

## Fix

Remove the redundant `directory` block from both apps. Git now matches the normalized live state, and `root` will go Synced on next comparison.

No child workloads change — this is purely at the `Application` spec level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)