### PR TITLE
fix(observability): point alert chat_id at the receiver bot, not the sender

### DIFF
--- a/apps/observability/grafana-values.yaml
+++ b/apps/observability/grafana-values.yaml
@@ -1687,7 +1687,7 @@ alerting:
             # Token"). $__env{} is interpolated at file read.
             settings:
               bottoken: $__env{GF_TELEGRAM_BOT_TOKEN}
-              chatid: "8859917575"
+              chatid: "8761422375"
   policies.yaml:
     apiVersion: 1
     policies:

--- a/apps/observability/prometheus-values.yaml
+++ b/apps/observability/prometheus-values.yaml
@@ -404,7 +404,7 @@ alertmanager:
       - name: notify
         telegram_configs:
           - bot_token_file: /etc/am-notify/telegram-bot-token
-            chat_id: 8859917575
+            chat_id: 8761422375
             parse_mode: HTML
             send_resolved: true
             # Custom body: name + status, description, and the dashboard deep-link


### PR DESCRIPTION
Fixes the alert target from #76.

## Problem
#76 set the Telegram `chat_id` to the **sender** bot's own ID. A bot cannot message itself, so alerts would not have delivered.

## Fix
Point `chat_id` at the **receiver** bot `@CjIncidentEngineerSrn_bot` (the Incident Response Telegram ingress). Bot-to-bot delivery to it was validated directly with `sendMessage` (`{ok:true}`, private chat). Alertmanager's `chat_id` is int-only (verified via `amtool check-config`), so the numeric ID is used in both:
- `apps/observability/prometheus-values.yaml` (Alertmanager `notify` receiver)
- `apps/observability/grafana-values.yaml` (Grafana `gemini-cost-telegram` contact point)

## After merge
`argocd app sync prometheus grafana` (the rotated bot token from #76 is already live via `observability-secrets`).