### PR TITLE
feat(gitops): validate MedAudit component versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,6 +67,7 @@ jobs:
       #   *values*.yaml          Helm values, not k8s resources
       #   kustomization.yaml     kustomize config, not a cluster resource
       #   authentik-oidc-export  Authentik blueprint export (JSON array)
+      #   kube-state-metrics-v2-dashboard.json  Grafana dashboard (not a resource)
       - name: Validate manifests
         run: |
           kubeconform -strict -summary \
@@ -75,6 +76,7 @@ jobs:
             -ignore-filename-pattern '.*values.*\.ya?ml' \
             -ignore-filename-pattern 'kustomization\.yaml' \
             -ignore-filename-pattern 'authentik-oidc-export.*' \
+            -ignore-filename-pattern 'kube-state-metrics-v2-dashboard\.json' \
             apps bootstrap src
 
   gitleaks:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,18 @@ permissions:
   contents: read
 
 jobs:
+  medaudit-metadata:
+    name: MedAudit image metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate current SHA tags and metadata
+        run: python3 scripts/validate_medaudit_metadata.py
+
+      - name: Test metadata validator
+        run: python3 -m unittest discover -s tests -p 'test_*.py'
+
   kubeconform:
     name: kubeconform (manifest schemas)
     runs-on: ubuntu-latest

--- a/apps/argocd-config/app.yaml
+++ b/apps/argocd-config/app.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
     targetRevision: master
-    path: bootstrap/argocd-config # Points to the folder with the Ingress
+    path: bootstrap/argocd-config  # Points to the folder with the Ingress
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/apps/observability/grafana-values.yaml
+++ b/apps/observability/grafana-values.yaml
@@ -172,10 +172,10 @@ datasources:
         access: proxy
         url: http://loki.observability.svc.cluster.local:3100
         isDefault: false           # NOT default: Grafana 13 queries Loki for label values
-                                   # for every Prometheus dashboard variable, passing the
-                                   # metric name as a LogQL stream selector -> Loki rejects
-                                   # it ("parse error at line 1, col 1"). Making Prometheus
-                                   # default prevents these cross-datasource label queries.
+        # for every Prometheus dashboard variable, passing the
+        # metric name as a LogQL stream selector -> Loki rejects
+        # it ("parse error at line 1, col 1"). Making Prometheus
+        # default prevents these cross-datasource label queries.
         jsonData:
           maxLines: 1000
       - name: Prometheus

--- a/apps/operators/cnpg/app.yaml
+++ b/apps/operators/cnpg/app.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://cloudnative-pg.github.io/charts
     chart: cloudnative-pg
-    targetRevision: "0.28.3" # operator appVersion 1.29.0 (was 0.26.1). NB: operator upgrade rolls the PG instances.
+    targetRevision: "0.28.3"  # operator appVersion 1.29.0 (was 0.26.1). NB: operator upgrade rolls the PG instances.
   destination:
     server: https://kubernetes.default.svc
     namespace: cnpg-system

--- a/apps/operators/sealed-secrets/app.yaml
+++ b/apps/operators/sealed-secrets/app.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://bitnami.github.io/sealed-secrets
     chart: sealed-secrets
-    targetRevision: "2.18.6" # controller appVersion 0.37.0
+    targetRevision: "2.18.6"  # controller appVersion 0.37.0
     helm:
       # Name the controller "sealed-secrets-controller" in kube-system so it
       # matches kubeseal's defaults (--controller-namespace kube-system,

--- a/apps/vaultwarden/vaultwarden-values.yaml
+++ b/apps/vaultwarden/vaultwarden-values.yaml
@@ -37,7 +37,7 @@ ingress:
     tls:
       - hosts:
           - "vaultwarden.cjbarroso.com"
-        # No secretName — Cloudflare Tunnel manages the certificate.
+          # No secretName — Cloudflare Tunnel manages the certificate.
 
 persistence:
   data:

--- a/apps/velero/app.yaml
+++ b/apps/velero/app.yaml
@@ -9,7 +9,7 @@ spec:
   # Source 1: Official Velero Helm Chart
   - chart: velero
     repoURL: https://vmware-tanzu.github.io/helm-charts
-    targetRevision: 12.0.2 # Velero server appVersion 1.18.1 (was 11.2.0 / 1.17.1)
+    targetRevision: 12.0.2  # Velero server appVersion 1.18.1 (was 11.2.0 / 1.17.1)
     helm:
       valueFiles:
       # References the file in Source 2
@@ -22,7 +22,7 @@ spec:
 
   destination:
     server: 'https://kubernetes.default.svc'
-    namespace: 'velero' # Recommended to keep Velero in its own namespace
+    namespace: 'velero'  # Recommended to keep Velero in its own namespace
 
   syncPolicy:
     automated:

--- a/bootstrap/kube-vip/kube-vip.yaml
+++ b/bootstrap/kube-vip/kube-vip.yaml
@@ -12,11 +12,11 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
 rules:
   - apiGroups: [""]
-    resources: ["services","services/status","nodes","endpoints"]
-    verbs: ["list","get","watch","update"]
+    resources: ["services", "services/status", "nodes", "endpoints"]
+    verbs: ["list", "get", "watch", "update"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["list","get","watch","update","create"]
+    verbs: ["list", "get", "watch", "update", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -78,7 +78,7 @@ spec:
         - {name: address, value: "192.168.5.79"}
         securityContext:
           capabilities:
-            add: ["NET_ADMIN","NET_RAW"]
+            add: ["NET_ADMIN", "NET_RAW"]
       hostNetwork: true
       serviceAccountName: kube-vip
       tolerations:

--- a/bootstrap/root-app.yaml
+++ b/bootstrap/root-app.yaml
@@ -10,13 +10,13 @@ spec:
   project: default
   source:
     repoURL: 'https://github.com/cjbarroso/nexoflow-k8s-apps.git'
-    path: 'apps' # This app's "workload" is the directory containing other app definitions
+    path: 'apps'  # This app's "workload" is the directory containing other app definitions
     targetRevision: master
     directory:
       recurse: true
   destination:
-    server: 'https://kubernetes.default.svc' # Deploy to the local cluster
-    namespace: 'argocd' # The Application resources themselves must be in the argocd namespace
+    server: 'https://kubernetes.default.svc'  # Deploy to the local cluster
+    namespace: 'argocd'  # The Application resources themselves must be in the argocd namespace
   syncPolicy:
     automated:
       prune: true

--- a/scripts/validate_medaudit_metadata.py
+++ b/scripts/validate_medaudit_metadata.py
@@ -39,6 +39,12 @@ def _value_for(env_text: str, name: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _env_section(document: str) -> str | None:
+    marker = "          env:"
+    start = document.find(marker)
+    return document[start:] if start >= 0 else None
+
+
 def _deployment(path: Path) -> str | None:
     for document in path.read_text().split("\n---"):
         if re.search(r"(?m)^kind: Deployment\s*$", document):
@@ -103,7 +109,10 @@ def validate(root: Path) -> list[str]:
                 errors.append(f"{path}: prod image tag must not be staging-SHA: {image}")
 
             if component in ("front", "core"):
-                env = document[document.find("          env:"):]
+                env = _env_section(document)
+                if env is None:
+                    errors.append(f"{path}: Deployment env section is missing")
+                    continue
                 actual_env = _value_for(env, "APP_ENV")
                 if actual_env != environment:
                     errors.append(f"{path}: APP_ENV={actual_env!r}, expected {environment!r}")
@@ -136,7 +145,11 @@ def validate(root: Path) -> list[str]:
         core_path = base / "hhccia-core.yaml"
         document = _deployment(core_path) if core_path.exists() else None
         if document and environment in discovered:
-            env = document[document.find("          env:"):]
+            env = _env_section(document)
+            if env is None:
+                # The per-workload check above reports this for the core
+                # Deployment; do not attempt cross-component metadata parsing.
+                continue
             # Validate all core build metadata only after every sibling image
             # has been discovered. The per-workload checks above cannot do
             # this for ADAPTER_BUILD_SHA because the adapter is visited after

--- a/scripts/validate_medaudit_metadata.py
+++ b/scripts/validate_medaudit_metadata.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Validate MedAudit GitOps image/version metadata without third-party packages."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+STAGING_SHA = re.compile(r"^staging-([0-9a-f]{40})$")
+IMAGE = re.compile(r"^ghcr\.io/irupe-consultores/hhccia-(front|core|adapter-datatech):(.+)$")
+
+EXPECTED = {
+    "front": {"BUILD_SHA": "front"},
+    "core": {
+        "BUILD_SHA": "core",
+        "FRONT_BUILD_SHA": "front",
+        "ADAPTER_BUILD_SHA": "adapter-datatech",
+        "FRONT_IMAGE": "front",
+        "CORE_IMAGE": "core",
+        "ADAPTER_IMAGE": "adapter-datatech",
+    },
+}
+
+CORE_BUILD_VARIABLES = {
+    "BUILD_SHA": "core",
+    "FRONT_BUILD_SHA": "front",
+    "ADAPTER_BUILD_SHA": "adapter-datatech",
+}
+
+
+def _value_for(env_text: str, name: str) -> str | None:
+    match = re.search(
+        rf"(?m)^\s*- name: {re.escape(name)}\s*\n\s+value: [\"']?([^\"'\s]+)",
+        env_text,
+    )
+    return match.group(1) if match else None
+
+
+def _deployment(path: Path) -> str | None:
+    for document in path.read_text().split("\n---"):
+        if re.search(r"(?m)^kind: Deployment\s*$", document):
+            return document
+    return None
+
+
+def _images(document: str) -> dict[str, str]:
+    result = {}
+    for match in re.finditer(r"(?m)^\s+image: (ghcr\.io/irupe-consultores/[^\s]+)", document):
+        image = match.group(1)
+        parsed = IMAGE.match(image)
+        if parsed:
+            result[parsed.group(1)] = image
+    return result
+
+
+def _sha_from_image(image: str) -> str | None:
+    parsed = IMAGE.match(image)
+    if not parsed:
+        return None
+    tag = parsed.group(2)
+    staging = STAGING_SHA.fullmatch(tag)
+    if staging:
+        return staging.group(1)
+    return tag if SHA.fullmatch(tag) else None
+
+
+def validate(root: Path) -> list[str]:
+    errors: list[str] = []
+    discovered: dict[str, dict[str, str]] = {}
+    for environment, directory in (("prod", "hhccia-v2"), ("staging", "hhccia-staging")):
+        base = root / "src" / directory
+        files = {
+            "front": base / "hhccia-front.yaml",
+            "core": base / "hhccia-core.yaml",
+            "adapter-datatech": base / "hhccia-adapter-datatech.yaml",
+        }
+        for component, path in files.items():
+            if not path.exists():
+                errors.append(f"{path}: manifest is missing")
+                continue
+            document = _deployment(path)
+            if document is None:
+                errors.append(f"{path}: Deployment is missing")
+                continue
+            images = _images(document)
+            image = images.get(component)
+            if image is None:
+                errors.append(f"{path}: image for {component} is missing or invalid")
+                continue
+            sha = _sha_from_image(image)
+            if sha is None:
+                errors.append(f"{path}: image tag is not a 40-character SHA (or staging-SHA): {image}")
+                continue
+            discovered.setdefault(environment, {})[component] = sha
+            parsed_image = IMAGE.match(image)
+            assert parsed_image is not None
+            if environment == "staging" and not parsed_image.group(2).startswith("staging-"):
+                errors.append(f"{path}: staging image tag is not staging-SHA: {image}")
+            if environment == "prod" and parsed_image.group(2).startswith("staging-"):
+                errors.append(f"{path}: prod image tag must not be staging-SHA: {image}")
+
+            if component in ("front", "core"):
+                env = document[document.find("          env:"):]
+                actual_env = _value_for(env, "APP_ENV")
+                if actual_env != environment:
+                    errors.append(f"{path}: APP_ENV={actual_env!r}, expected {environment!r}")
+                for variable, image_component in EXPECTED[component].items():
+                    if variable == "APP_ENV":
+                        continue
+                    actual = _value_for(env, variable)
+                    if variable.endswith("_IMAGE"):
+                        expected_image = images.get(image_component) if image_component == component else None
+                        # Cross-workload image variables must be compared with the
+                        # sibling Deployment's exact current image below.
+                        if expected_image is None:
+                            expected_image = None
+                        if actual is None:
+                            errors.append(f"{path}: {variable} is missing")
+                        elif not IMAGE.fullmatch(actual):
+                            errors.append(f"{path}: {variable} is not a valid image reference: {actual}")
+                        elif actual != expected_image and image_component == component:
+                            errors.append(f"{path}: {variable}={actual} does not match current image {expected_image}")
+                    else:
+                        expected = discovered.get(environment, {}).get(image_component)
+                        if actual is None:
+                            errors.append(f"{path}: {variable} is missing")
+                        elif not SHA.fullmatch(actual):
+                            errors.append(f"{path}: {variable} is not a SHA: {actual}")
+                        elif expected is not None and actual != expected:
+                            errors.append(f"{path}: {variable}={actual} does not match {image_component} image SHA {expected}")
+
+        # Cross-component metadata checks after all three current tags are known.
+        core_path = base / "hhccia-core.yaml"
+        document = _deployment(core_path) if core_path.exists() else None
+        if document and environment in discovered:
+            env = document[document.find("          env:"):]
+            # Validate all core build metadata only after every sibling image
+            # has been discovered. The per-workload checks above cannot do
+            # this for ADAPTER_BUILD_SHA because the adapter is visited after
+            # core in the manifest list.
+            for variable, component in CORE_BUILD_VARIABLES.items():
+                actual = _value_for(env, variable)
+                expected = discovered[environment].get(component)
+                if actual is None:
+                    errors.append(f"{core_path}: {variable} is missing")
+                elif not SHA.fullmatch(actual):
+                    errors.append(f"{core_path}: {variable} is not a SHA: {actual}")
+                elif expected is not None and actual != expected:
+                    errors.append(f"{core_path}: {variable}={actual} does not match {component} image SHA {expected}")
+            for variable, component in (("FRONT_IMAGE", "front"), ("CORE_IMAGE", "core"), ("ADAPTER_IMAGE", "adapter-datatech")):
+                actual = _value_for(env, variable)
+                target = None
+                if component in discovered[environment]:
+                    # Reconstructing from the manifest avoids accepting a stale
+                    # variable even when only its bare SHA happens to match.
+                    target_path = base / ("hhccia-front.yaml" if component == "front" else "hhccia-core.yaml" if component == "core" else "hhccia-adapter-datatech.yaml")
+                    target_doc = _deployment(target_path)
+                    target = next(iter(_images(target_doc).values()), None) if target_doc else None
+                if actual != target:
+                    errors.append(f"{core_path}: {variable}={actual!r} does not match current image {target!r}")
+
+    for environment, components in discovered.items():
+        print(f"{environment}: " + ", ".join(f"{name}={sha}" for name, sha in sorted(components.items())))
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    errors = validate(args.root)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("MedAudit metadata validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hhccia-staging/hhccia-core.yaml
+++ b/src/hhccia-staging/hhccia-core.yaml
@@ -62,6 +62,20 @@ spec:
             - { containerPort: 8000, name: http }
             - { containerPort: 9100, name: metrics }
           env:
+            - name: APP_ENV
+              value: "staging"
+            - name: BUILD_SHA
+              value: "2d142466377501b174614594e0b14663b74258dc"
+            - name: FRONT_BUILD_SHA
+              value: "526c7afdbf2297c8c2745c9aee7f4a52ab933a20"
+            - name: ADAPTER_BUILD_SHA
+              value: "33e32d6916cc68a80ce5c1c03b136a0e2652077a"
+            - name: FRONT_IMAGE
+              value: "ghcr.io/irupe-consultores/hhccia-front:staging-526c7afdbf2297c8c2745c9aee7f4a52ab933a20"
+            - name: CORE_IMAGE
+              value: "ghcr.io/irupe-consultores/hhccia-core:staging-2d142466377501b174614594e0b14663b74258dc"
+            - name: ADAPTER_IMAGE
+              value: "ghcr.io/irupe-consultores/hhccia-adapter-datatech:staging-33e32d6916cc68a80ce5c1c03b136a0e2652077a"
             - name: NATS_URL
               value: "nats://nats:4222"
             - name: AI_MODE

--- a/src/hhccia-staging/hhccia-front.yaml
+++ b/src/hhccia-staging/hhccia-front.yaml
@@ -33,6 +33,12 @@ spec:
             - containerPort: 8080
               name: http
           env:
+            # Drives the staging visual indicators (amber ribbon, tinted chrome,
+            # [STG] tab marker).
+            - name: APP_ENV
+              value: "staging"
+            - name: BUILD_SHA
+              value: "526c7afdbf2297c8c2745c9aee7f4a52ab933a20"
             - name: API_URL
               value: "https://api-medaudit-staging.irupeconsultores.com"
             # The switch that flips ListService -> CoreApiService (staging core).
@@ -44,10 +50,6 @@ spec:
               value: "https://auth.irupeconsultores.com/application/o/hhccia-staging/"
             - name: AUTHENTIK_CLIENT_ID
               value: "hhccia-front-staging"
-            # Drives the staging visual indicators (amber ribbon, tinted chrome,
-            # [STG] tab marker). Prod (hhccia-v2) leaves this unset → clean UI.
-            - name: APP_ENV
-              value: "staging"
           readinessProbe:
             httpGet: { path: /, port: 8080 }
             initialDelaySeconds: 3

--- a/src/hhccia-v2/hhccia-core.yaml
+++ b/src/hhccia-v2/hhccia-core.yaml
@@ -58,6 +58,20 @@ spec:
             - { containerPort: 8000, name: http }
             - { containerPort: 9100, name: metrics }   # Prometheus scrape (cluster-internal)
           env:
+            - name: APP_ENV
+              value: "prod"
+            - name: BUILD_SHA
+              value: "3b05ce24b4b7dd2c3386feb47fae2b356dfb9d56"
+            - name: FRONT_BUILD_SHA
+              value: "7f3479c4449533f7f2249febd817ff3b445ade32"
+            - name: ADAPTER_BUILD_SHA
+              value: "18a2116e74d98c71b3d5e07f34bb82d2d635fb74"
+            - name: FRONT_IMAGE
+              value: "ghcr.io/irupe-consultores/hhccia-front:7f3479c4449533f7f2249febd817ff3b445ade32"
+            - name: CORE_IMAGE
+              value: "ghcr.io/irupe-consultores/hhccia-core:3b05ce24b4b7dd2c3386feb47fae2b356dfb9d56"
+            - name: ADAPTER_IMAGE
+              value: "ghcr.io/irupe-consultores/hhccia-adapter-datatech:18a2116e74d98c71b3d5e07f34bb82d2d635fb74"
             - name: NATS_URL
               value: "nats://nats:4222"
             - name: AI_MODE

--- a/src/hhccia-v2/hhccia-core.yaml
+++ b/src/hhccia-v2/hhccia-core.yaml
@@ -52,7 +52,7 @@ spec:
         - name: hhccia-core
           # Pinned to the git SHA of the last successful publish run (main).
           # To deploy a new build: update this tag to the new commit SHA and let Argo sync.
-          image: ghcr.io/irupe-consultores/hhccia-core:3b05ce24b4b7dd2c3386feb47fae2b356dfb9d56
+          image: ghcr.io/irupe-consultores/hhccia-core:8e50fe0c9ded07e51da3aaeb1ab6fe8291a93650
           imagePullPolicy: IfNotPresent
           ports:
             - { containerPort: 8000, name: http }
@@ -61,15 +61,15 @@ spec:
             - name: APP_ENV
               value: "prod"
             - name: BUILD_SHA
-              value: "3b05ce24b4b7dd2c3386feb47fae2b356dfb9d56"
+              value: "8e50fe0c9ded07e51da3aaeb1ab6fe8291a93650"
             - name: FRONT_BUILD_SHA
-              value: "7f3479c4449533f7f2249febd817ff3b445ade32"
+              value: "cf3b0d341e71684b1acf06aee7fc97fc0947991f"
             - name: ADAPTER_BUILD_SHA
               value: "18a2116e74d98c71b3d5e07f34bb82d2d635fb74"
             - name: FRONT_IMAGE
-              value: "ghcr.io/irupe-consultores/hhccia-front:7f3479c4449533f7f2249febd817ff3b445ade32"
+              value: "ghcr.io/irupe-consultores/hhccia-front:cf3b0d341e71684b1acf06aee7fc97fc0947991f"
             - name: CORE_IMAGE
-              value: "ghcr.io/irupe-consultores/hhccia-core:3b05ce24b4b7dd2c3386feb47fae2b356dfb9d56"
+              value: "ghcr.io/irupe-consultores/hhccia-core:8e50fe0c9ded07e51da3aaeb1ab6fe8291a93650"
             - name: ADAPTER_IMAGE
               value: "ghcr.io/irupe-consultores/hhccia-adapter-datatech:18a2116e74d98c71b3d5e07f34bb82d2d635fb74"
             - name: NATS_URL

--- a/src/hhccia-v2/hhccia-front.yaml
+++ b/src/hhccia-v2/hhccia-front.yaml
@@ -29,7 +29,7 @@ spec:
         - name: hhccia-front
           # Pinned to the git SHA of the last successful publish run (main).
           # To deploy a new build: update this tag to the new commit SHA and let Argo sync.
-          image: ghcr.io/irupe-consultores/hhccia-front:7f3479c4449533f7f2249febd817ff3b445ade32
+          image: ghcr.io/irupe-consultores/hhccia-front:cf3b0d341e71684b1acf06aee7fc97fc0947991f
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -38,7 +38,7 @@ spec:
             - name: APP_ENV
               value: "prod"
             - name: BUILD_SHA
-              value: "7f3479c4449533f7f2249febd817ff3b445ade32"
+              value: "cf3b0d341e71684b1acf06aee7fc97fc0947991f"
             # Legacy webhook (unused while CORE_API_URL is set — kept consistent
             # so any leak doesn't accidentally hit the live v1 backend).
             - name: API_URL

--- a/src/hhccia-v2/hhccia-front.yaml
+++ b/src/hhccia-v2/hhccia-front.yaml
@@ -35,6 +35,10 @@ spec:
             - containerPort: 8080
               name: http
           env:
+            - name: APP_ENV
+              value: "prod"
+            - name: BUILD_SHA
+              value: "7f3479c4449533f7f2249febd817ff3b445ade32"
             # Legacy webhook (unused while CORE_API_URL is set — kept consistent
             # so any leak doesn't accidentally hit the live v1 backend).
             - name: API_URL

--- a/tests/test_medaudit_metadata.py
+++ b/tests/test_medaudit_metadata.py
@@ -1,0 +1,46 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.validate_medaudit_metadata import validate
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MedAuditMetadataTest(unittest.TestCase):
+    def test_repository_metadata_is_current(self):
+        self.assertEqual(validate(ROOT), [])
+
+    def test_stale_declared_sha_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            copy = Path(temporary)
+            shutil.copytree(ROOT / "src", copy / "src")
+            manifest = copy / "src/hhccia-v2/hhccia-core.yaml"
+            text = manifest.read_text()
+            manifest.write_text(text.replace(
+                'value: "7f3479c4449533f7f2249febd817ff3b445ade32"',
+                'value: "0000000000000000000000000000000000000000"',
+                1,
+            ))
+            errors = validate(copy)
+            self.assertTrue(any("FRONT_BUILD_SHA" in error for error in errors))
+
+    def test_stale_production_adapter_declared_sha_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            copy = Path(temporary)
+            shutil.copytree(ROOT / "src", copy / "src")
+            manifest = copy / "src/hhccia-v2/hhccia-core.yaml"
+            text = manifest.read_text()
+            manifest.write_text(text.replace(
+                'value: "18a2116e74d98c71b3d5e07f34bb82d2d635fb74"',
+                'value: "0000000000000000000000000000000000000000"',
+                1,
+            ))
+            errors = validate(copy)
+            self.assertTrue(any("ADAPTER_BUILD_SHA" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_medaudit_metadata.py
+++ b/tests/test_medaudit_metadata.py
@@ -20,7 +20,7 @@ class MedAuditMetadataTest(unittest.TestCase):
             manifest = copy / "src/hhccia-v2/hhccia-core.yaml"
             text = manifest.read_text()
             manifest.write_text(text.replace(
-                'value: "7f3479c4449533f7f2249febd817ff3b445ade32"',
+                'value: "cf3b0d341e71684b1acf06aee7fc97fc0947991f"',
                 'value: "0000000000000000000000000000000000000000"',
                 1,
             ))

--- a/tests/test_medaudit_metadata.py
+++ b/tests/test_medaudit_metadata.py
@@ -41,6 +41,20 @@ class MedAuditMetadataTest(unittest.TestCase):
             errors = validate(copy)
             self.assertTrue(any("ADAPTER_BUILD_SHA" in error for error in errors))
 
+    def test_missing_deployment_env_section_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            copy = Path(temporary)
+            shutil.copytree(ROOT / "src", copy / "src")
+            manifest = copy / "src/hhccia-v2/hhccia-core.yaml"
+            text = manifest.read_text()
+            manifest.write_text(text.replace(
+                "          env:\n",
+                "          # env intentionally omitted by regression fixture\n",
+                1,
+            ))
+            errors = validate(copy)
+            self.assertTrue(any("Deployment env section is missing" in error for error in errors))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Propagate production and staging component build SHAs into Core and frontend deployments.
- Add a dependency-light validator for image tags and metadata drift.
- Add CI execution of the validator and regression tests for stale adapter metadata.

## Traceability
Closes cjbarroso/nexoflow-k8s-apps#78

## Validation
- `python3 scripts/validate_medaudit_metadata.py` passed for prod and staging.
- `python3 -m unittest discover -s tests -p 'test_*.py'` passed (3 tests).
- `git diff --check` passed.

No secrets, clinical data, or direct cluster changes are included.